### PR TITLE
add validation generation.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,7 @@ module github.com/contiamo/openapi-generator-go
 go 1.15
 
 require (
-	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect
 	github.com/getkin/kin-openapi v0.14.0
-	github.com/go-chi/chi v4.0.2+incompatible
-	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.8.1
 	github.com/rs/zerolog v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef h1:46PFijGLmAjMPwCCCo7Jf0W6f9slllCkkv7vyc1yOSg=
-github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
@@ -46,14 +44,10 @@ github.com/getkin/kin-openapi v0.14.0 h1:hqwQL7kze/adt0wB+0UJR2nJm+gfUHqM0Gu4D8n
 github.com/getkin/kin-openapi v0.14.0/go.mod h1:WGRs2ZMM1Q8LR1QBEwUxC6RJEfaBcD0s+pcEVXFuAjw=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=
-github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
-github.com/go-ozzo/ozzo-validation v3.6.0+incompatible h1:msy24VGS42fKO9K1vLz82/GeYW1cILu7Nuuj1N3BBkE=
-github.com/go-ozzo/ozzo-validation v3.6.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=

--- a/pkg/generators/models/go_type_from_ref.go
+++ b/pkg/generators/models/go_type_from_ref.go
@@ -41,9 +41,23 @@ func goTypeFromSpec(schemaRef *openapi3.SchemaRef) string {
 	case "boolean":
 		propertyType = "bool"
 	case "integer":
-		propertyType = "int32"
+		switch schemaRef.Value.Format {
+		case "int32":
+			propertyType = "int32"
+		case "int64":
+			propertyType = "int64"
+		default:
+			propertyType = "int64"
+		}
 	case "number":
-		propertyType = "float32"
+		switch schemaRef.Value.Format {
+		case "float":
+			propertyType = "float32"
+		case "double":
+			propertyType = "float64"
+		default:
+			propertyType = "float64"
+		}
 	case "":
 		if schemaRef.Ref != "" {
 			propertyType = filepath.Base(schemaRef.Ref)

--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -235,10 +235,10 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 	case "ip":
 		spec.IsIP = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
-	case "":
+	case "", "int32", "int64", "float", "double":
 		break // do nothing
 	default:
-		log.Warn().Str("format", ref.Value.Format).Msg("unknown format")
+		log.Warn().Str("name", spec.Name).Str("format", ref.Value.Format).Msg("unknown format")
 	}
 	return imports
 }

--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -39,12 +39,12 @@ type PropSpec struct {
 	Description string
 	GoType      string
 	JSONTags    string
-	AsPointer   bool
 	Value       string
 	IsRequired  bool
 	IsEnum      bool
 
 	// Validation stuff
+	IsNullable                 bool
 	NeedsValidation            bool
 	IsRequiredInValidation     bool
 	HasMin, HasMax             bool
@@ -150,8 +150,8 @@ func structPropsFromRef(ref *openapi3.SchemaRef) (specs []PropSpec, imports []st
 			GoType:      goTypeFromSpec(prop),
 			IsRequired:  checkIfRequired(name, ref.Value.Required),
 			IsEnum:      len(prop.Value.Enum) > 0,
+			IsNullable:  prop.Value.Nullable,
 		}
-		spec.AsPointer = !spec.IsRequired
 
 		if spec.GoType == "time.Time" || spec.GoType == "*time.Time" {
 			imports = append(imports, "time")
@@ -176,7 +176,7 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 		(len(spec.GoType) > 2 && spec.GoType[:3] == "map") {
 		// enable recursive validation
 		spec.NeedsValidation = true
-		spec.IsRequiredInValidation = spec.IsRequired
+		spec.IsRequiredInValidation = !spec.IsNullable
 	}
 
 	if ref.Value.Min != nil {
@@ -184,7 +184,7 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 		spec.HasMin = true
 		spec.Min = *ref.Value.Min
 		if spec.Min > 0 {
-			spec.IsRequiredInValidation = spec.IsRequired
+			spec.IsRequiredInValidation = !spec.IsNullable
 		}
 	}
 	if ref.Value.Max != nil {
@@ -192,7 +192,7 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 		spec.HasMax = true
 		spec.Max = *ref.Value.Max
 		if spec.Max > 0 {
-			spec.IsRequiredInValidation = spec.IsRequired
+			spec.IsRequiredInValidation = !spec.IsNullable
 		}
 	}
 	if ref.Value.MinLength > 0 {
@@ -200,16 +200,15 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 		spec.HasMinLength = true
 		spec.MinLength = ref.Value.MinLength
 		if spec.MinLength > 0 {
-			spec.IsRequiredInValidation = spec.IsRequired
+			spec.IsRequiredInValidation = !spec.IsNullable
 		}
-
 	}
 	if ref.Value.MaxLength != nil {
 		spec.NeedsValidation = true
 		spec.HasMaxLength = true
 		spec.MaxLength = *ref.Value.MaxLength
 		if spec.MaxLength > 0 {
-			spec.IsRequiredInValidation = spec.IsRequired
+			spec.IsRequiredInValidation = !spec.IsNullable
 		}
 	}
 	if ref.Value.ExclusiveMin {
@@ -220,51 +219,51 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 	}
 	switch ref.Value.Format {
 	case "date":
-		spec.IsRequiredInValidation = spec.IsRequired
-		spec.NeedsValidation = true
+		spec.IsRequiredInValidation = !spec.IsNullable
+		spec.IsRequired = true
 		spec.IsDate = true
 	case "date-time":
-		spec.IsRequiredInValidation = spec.IsRequired
-		spec.NeedsValidation = true
+		spec.IsRequiredInValidation = !spec.IsNullable
+		spec.IsRequired = true
 		spec.IsDateTime = true
 		imports = append(imports, "time")
 	case "byte":
-		spec.IsRequiredInValidation = spec.IsRequired
+		spec.IsRequiredInValidation = !spec.IsNullable
 		spec.NeedsValidation = true
 		spec.IsBase64 = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "email":
-		spec.IsRequiredInValidation = spec.IsRequired
+		spec.IsRequiredInValidation = !spec.IsNullable
 		spec.NeedsValidation = true
 		spec.IsEmail = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "uuid":
-		spec.IsRequiredInValidation = spec.IsRequired
+		spec.IsRequiredInValidation = !spec.IsNullable
 		spec.NeedsValidation = true
 		spec.IsUUID = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "url":
-		spec.IsRequiredInValidation = spec.IsRequired
+		spec.IsRequiredInValidation = !spec.IsNullable
 		spec.NeedsValidation = true
 		spec.IsURL = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "hostname":
-		spec.IsRequiredInValidation = spec.IsRequired
+		spec.IsRequiredInValidation = !spec.IsNullable
 		spec.NeedsValidation = true
 		spec.IsHostname = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "ipv4":
-		spec.IsRequiredInValidation = spec.IsRequired
+		spec.IsRequiredInValidation = !spec.IsNullable
 		spec.NeedsValidation = true
 		spec.IsIPv4 = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "ipv6":
-		spec.IsRequiredInValidation = spec.IsRequired
+		spec.IsRequiredInValidation = !spec.IsNullable
 		spec.NeedsValidation = true
 		spec.IsIPv6 = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "ip":
-		spec.IsRequiredInValidation = spec.IsRequired
+		spec.IsRequiredInValidation = !spec.IsNullable
 		spec.NeedsValidation = true
 		spec.IsIP = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")

--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -296,10 +296,10 @@ func (m {{$modelName}}) Validate() error {
 			{{- if .IsEmail }}is.Email,{{ end }}
 			{{- if .IsUUID }}is.UUID,{{ end }}
 			{{- if .IsURL }}is.RequestURL,{{ end }}
-		  {{- if .IsHostname }}is.Host,{{ end }}
-		  {{- if .IsIPv4 }}is.IPv4,{{ end }}
-		  {{- if .IsIPv6 }}is.IPv6,{{ end }}
-		  {{- if .IsIP }}is.IP,{{ end }}
+			{{- if .IsHostname }}is.Host,{{ end }}
+			{{- if .IsIPv4 }}is.IPv4,{{ end }}
+			{{- if .IsIPv6 }}is.IPv6,{{ end }}
+			{{- if .IsIP }}is.IP,{{ end }}
 		),
 	{{- end }}
 	}.Filter()

--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -394,8 +394,6 @@ var constTemplate = template.Must(
 )
 
 func uniqueStrings(input []string) (output []string) {
-	fmt.Println("in", input)
-	defer fmt.Println("out", output)
 	m := make(map[string]struct{})
 	for _, item := range input {
 		if _, ok := m[item]; ok {

--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -176,7 +176,7 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 		(len(spec.GoType) > 2 && spec.GoType[:3] == "map") {
 		// enable recursive validation
 		spec.NeedsValidation = true
-		spec.IsRequiredInValidation = !spec.IsNullable
+		spec.IsRequiredInValidation = !spec.IsNullable && spec.IsRequired
 	}
 
 	if ref.Value.Min != nil {
@@ -184,7 +184,7 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 		spec.HasMin = true
 		spec.Min = *ref.Value.Min
 		if spec.Min > 0 {
-			spec.IsRequiredInValidation = !spec.IsNullable
+			spec.IsRequiredInValidation = !spec.IsNullable && spec.IsRequired
 		}
 	}
 	if ref.Value.Max != nil {
@@ -192,7 +192,7 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 		spec.HasMax = true
 		spec.Max = *ref.Value.Max
 		if spec.Max > 0 {
-			spec.IsRequiredInValidation = !spec.IsNullable
+			spec.IsRequiredInValidation = !spec.IsNullable && spec.IsRequired
 		}
 	}
 	if ref.Value.MinLength > 0 {
@@ -200,7 +200,7 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 		spec.HasMinLength = true
 		spec.MinLength = ref.Value.MinLength
 		if spec.MinLength > 0 {
-			spec.IsRequiredInValidation = !spec.IsNullable
+			spec.IsRequiredInValidation = !spec.IsNullable && spec.IsRequired
 		}
 	}
 	if ref.Value.MaxLength != nil {
@@ -208,7 +208,7 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 		spec.HasMaxLength = true
 		spec.MaxLength = *ref.Value.MaxLength
 		if spec.MaxLength > 0 {
-			spec.IsRequiredInValidation = !spec.IsNullable
+			spec.IsRequiredInValidation = !spec.IsNullable && spec.IsRequired
 		}
 	}
 	if ref.Value.ExclusiveMin {
@@ -219,51 +219,51 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 	}
 	switch ref.Value.Format {
 	case "date":
-		spec.IsRequiredInValidation = !spec.IsNullable
+		spec.IsRequiredInValidation = !spec.IsNullable && spec.IsRequired
 		spec.IsRequired = true
 		spec.IsDate = true
 	case "date-time":
-		spec.IsRequiredInValidation = !spec.IsNullable
+		spec.IsRequiredInValidation = !spec.IsNullable && spec.IsRequired
 		spec.IsRequired = true
 		spec.IsDateTime = true
 		imports = append(imports, "time")
 	case "byte":
-		spec.IsRequiredInValidation = !spec.IsNullable
+		spec.IsRequiredInValidation = !spec.IsNullable && spec.IsRequired
 		spec.NeedsValidation = true
 		spec.IsBase64 = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "email":
-		spec.IsRequiredInValidation = !spec.IsNullable
+		spec.IsRequiredInValidation = !spec.IsNullable && spec.IsRequired
 		spec.NeedsValidation = true
 		spec.IsEmail = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "uuid":
-		spec.IsRequiredInValidation = !spec.IsNullable
+		spec.IsRequiredInValidation = !spec.IsNullable && spec.IsRequired
 		spec.NeedsValidation = true
 		spec.IsUUID = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "url":
-		spec.IsRequiredInValidation = !spec.IsNullable
+		spec.IsRequiredInValidation = !spec.IsNullable && spec.IsRequired
 		spec.NeedsValidation = true
 		spec.IsURL = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "hostname":
-		spec.IsRequiredInValidation = !spec.IsNullable
+		spec.IsRequiredInValidation = !spec.IsNullable && spec.IsRequired
 		spec.NeedsValidation = true
 		spec.IsHostname = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "ipv4":
-		spec.IsRequiredInValidation = !spec.IsNullable
+		spec.IsRequiredInValidation = !spec.IsNullable && spec.IsRequired
 		spec.NeedsValidation = true
 		spec.IsIPv4 = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "ipv6":
-		spec.IsRequiredInValidation = !spec.IsNullable
+		spec.IsRequiredInValidation = !spec.IsNullable && spec.IsRequired
 		spec.NeedsValidation = true
 		spec.IsIPv6 = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "ip":
-		spec.IsRequiredInValidation = !spec.IsNullable
+		spec.IsRequiredInValidation = !spec.IsNullable && spec.IsRequired
 		spec.NeedsValidation = true
 		spec.IsIP = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")

--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -176,6 +176,7 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 		(len(spec.GoType) > 2 && spec.GoType[:3] == "map") {
 		// enable recursive validation
 		spec.NeedsValidation = true
+		spec.IsRequiredInValidation = spec.IsRequired
 	}
 
 	if ref.Value.Min != nil {
@@ -183,7 +184,7 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 		spec.HasMin = true
 		spec.Min = *ref.Value.Min
 		if spec.Min > 0 {
-			spec.IsRequiredInValidation = true
+			spec.IsRequiredInValidation = spec.IsRequired
 		}
 	}
 	if ref.Value.Max != nil {
@@ -191,7 +192,7 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 		spec.HasMax = true
 		spec.Max = *ref.Value.Max
 		if spec.Max > 0 {
-			spec.IsRequiredInValidation = true
+			spec.IsRequiredInValidation = spec.IsRequired
 		}
 	}
 	if ref.Value.MinLength > 0 {
@@ -199,7 +200,7 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 		spec.HasMinLength = true
 		spec.MinLength = ref.Value.MinLength
 		if spec.MinLength > 0 {
-			spec.IsRequiredInValidation = true
+			spec.IsRequiredInValidation = spec.IsRequired
 		}
 
 	}
@@ -208,7 +209,7 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 		spec.HasMaxLength = true
 		spec.MaxLength = *ref.Value.MaxLength
 		if spec.MaxLength > 0 {
-			spec.IsRequiredInValidation = true
+			spec.IsRequiredInValidation = spec.IsRequired
 		}
 	}
 	if ref.Value.ExclusiveMin {
@@ -219,41 +220,51 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 	}
 	switch ref.Value.Format {
 	case "date":
+		spec.IsRequiredInValidation = spec.IsRequired
 		spec.NeedsValidation = true
 		spec.IsDate = true
 	case "date-time":
+		spec.IsRequiredInValidation = spec.IsRequired
 		spec.NeedsValidation = true
 		spec.IsDateTime = true
 		imports = append(imports, "time")
 	case "byte":
+		spec.IsRequiredInValidation = spec.IsRequired
 		spec.NeedsValidation = true
 		spec.IsBase64 = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "email":
+		spec.IsRequiredInValidation = spec.IsRequired
 		spec.NeedsValidation = true
 		spec.IsEmail = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "uuid":
+		spec.IsRequiredInValidation = spec.IsRequired
 		spec.NeedsValidation = true
 		spec.IsUUID = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "url":
+		spec.IsRequiredInValidation = spec.IsRequired
 		spec.NeedsValidation = true
 		spec.IsURL = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "hostname":
+		spec.IsRequiredInValidation = spec.IsRequired
 		spec.NeedsValidation = true
 		spec.IsHostname = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "ipv4":
+		spec.IsRequiredInValidation = spec.IsRequired
 		spec.NeedsValidation = true
 		spec.IsIPv4 = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "ipv6":
+		spec.IsRequiredInValidation = spec.IsRequired
 		spec.NeedsValidation = true
 		spec.IsIPv6 = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
 	case "ip":
+		spec.IsRequiredInValidation = spec.IsRequired
 		spec.NeedsValidation = true
 		spec.IsIP = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")

--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -45,6 +45,7 @@ type PropSpec struct {
 	IsEnum      bool
 
 	// Validation stuff
+	IsRequiredInValidation     bool
 	HasMin, HasMax             bool
 	Min, Max                   float64
 	HasMinLength, HasMaxLength bool
@@ -172,18 +173,31 @@ func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (i
 	if ref.Value.Min != nil {
 		spec.HasMin = true
 		spec.Min = *ref.Value.Min
+		if spec.Min > 0 {
+			spec.IsRequiredInValidation = true
+		}
 	}
 	if ref.Value.Max != nil {
 		spec.HasMax = true
 		spec.Max = *ref.Value.Max
+		if spec.Max > 0 {
+			spec.IsRequiredInValidation = true
+		}
 	}
 	if ref.Value.MinLength > 0 {
 		spec.HasMinLength = true
 		spec.MinLength = ref.Value.MinLength
+		if spec.MinLength > 0 {
+			spec.IsRequiredInValidation = true
+		}
+
 	}
 	if ref.Value.MaxLength != nil {
 		spec.HasMaxLength = true
 		spec.MaxLength = *ref.Value.MaxLength
+		if spec.MaxLength > 0 {
+			spec.IsRequiredInValidation = true
+		}
 	}
 	if ref.Value.ExclusiveMin {
 		spec.Min += math.SmallestNonzeroFloat64

--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -161,14 +161,14 @@ func structPropsFromRef(ref *openapi3.SchemaRef) (specs []PropSpec, imports []st
 		}
 		spec.JSONTags += "\"`"
 
-		imports = append(imports, fillValidationRelatedStuff(prop, &spec)...)
+		imports = append(imports, fillValidationRelatedProperties(prop, &spec)...)
 
 		specs = append(specs, spec)
 	}
 	return specs, uniqueStrings(imports), err
 }
 
-func fillValidationRelatedStuff(ref *openapi3.SchemaRef, spec *PropSpec) (imports []string) {
+func fillValidationRelatedProperties(ref *openapi3.SchemaRef, spec *PropSpec) (imports []string) {
 	if ref.Value.Min != nil {
 		spec.HasMin = true
 		spec.Min = *ref.Value.Min
@@ -252,150 +252,6 @@ func checkIfRequired(name string, list []string) bool {
 	}
 	return false
 }
-
-var modelTemplateSource = `// This file is auto-generated, DO NOT EDIT.
-//
-// Source:
-//     Title: {{.SpecTitle}}
-//     Version: {{.SpecVersion}}
-package {{ .PackageName }}
-
-import (
-	validation "github.com/go-ozzo/ozzo-validation/v4"
-{{- range .Imports}}
-	"{{.}}"
-{{ end}}
-)
-
-{{ (printf "%s is an object. %s" .Name .Description) | commentBlock }}
-{{- if not .Properties }}
-type {{.Name}} map[string]interface{}
-{{- else }}
-type {{.Name}} struct {
-{{- range .Properties}}
-	{{ (printf "%s: %s" .Name .Description) | commentBlock }}
-	{{.Name}} {{.GoType}} {{.JSONTags}}
-{{- end}}
-}
-{{- end}}
-
-{{- $modelName := .Name }}
-// Validate implements basic validation for this model
-func (m {{$modelName}}) Validate() error {
-	return validation.Errors{
-		{{- range .Properties}}
-		"{{ firstLower .Name }}": validation.Validate(
-			m.{{ .Name }},
-			{{- if .HasMin }}validation.Min({{ .GoType }}({{ .Min }})),{{ end }}
-			{{- if .HasMax }}validation.Max({{ .GoType }}({{ .Max }})),{{ end }}
-			{{- if or .HasMinLength .HasMaxLength }}validation.Length({{ .MinLength }},{{ .MaxLength }}),{{ end }}
-			{{- if .IsEnum }}InKnown{{ .GoType }},{{ end }}
-			{{- if .IsDate }}validation.Date("2006-01-02"),{{ end }}
-			{{- if .IsDateTime }}validation.Date(time.RFC3339),{{ end }}
-			{{- if .IsBase64 }}is.Base64,{{ end }}
-			{{- if .IsEmail }}is.Email,{{ end }}
-			{{- if .IsUUID }}is.UUID,{{ end }}
-			{{- if .IsURL }}is.RequestURL,{{ end }}
-			{{- if .IsHostname }}is.Host,{{ end }}
-			{{- if .IsIPv4 }}is.IPv4,{{ end }}
-			{{- if .IsIPv6 }}is.IPv6,{{ end }}
-			{{- if .IsIP }}is.IP,{{ end }}
-		),
-	{{- end }}
-	}.Filter()
-}
-{{ range .Properties}}
-// Get{{.Name}} returns the {{.Name}} property
-func (m {{$modelName}}) Get{{.Name}}() {{.GoType}} {
-	return m.{{.Name}}
-}
-
-// Set{{.Name}} sets the {{.Name}} property
-func (m {{$modelName}}) Set{{.Name}}(val {{.GoType}}) {
-	m.{{.Name}} = val
-}
-{{ end}}`
-
-var enumTemplateSource = `
-// This file is auto-generated, DO NOT EDIT.
-//
-// Source:
-//     Title: {{.SpecTitle}}
-//     Version: {{.SpecVersion}}
-package {{ .PackageName }}
-
-import (
-	validation "github.com/go-ozzo/ozzo-validation"
-)
-
-{{ (printf "%s is an enum. %s" .Name .Description) | commentBlock }}
-type {{.Name}} {{.GoType}}
-
-var (
-	{{- $enum :=. }}
-	{{- range $v := .Properties }}
-	{{$enum.Name}}{{$v.Name}} {{$enum.Name}} = {{$v.Value}}
-	{{- end}}
-
-	// Known{{.Name}} is the list of valid {{.Name}}
-	Known{{.Name }} = []{{.Name}}{
-		{{- range $v := .Properties }}
-		{{$enum.Name}}{{$v.Name}},
-		{{- end}}
-	}
-
-	{{- $enum :=. }}
-	// Known{{$enum.Name}}{{$enum.GoType | firstUpper}} is the list of valid {{$enum.Name}} as {{$enum.GoType}}
-	Known{{$enum.Name}}{{$enum.GoType | firstUpper}} = []{{$enum.GoType}}{
-		{{- range $v := .Properties }}
-		{{$enum.GoType}}({{$enum.Name}}{{$v.Name}}),
-		{{- end}}
-	}
-
-	// InKnown{{.Name}} is an ozzo-validator for {{.Name}}
-	InKnown{{.Name}} = validation.In(
-		{{- range $v := .Properties }}
-		{{$enum.Name}}{{$v.Name}},
-		{{- end}}
-	)
-)
-`
-
-var constTemplateSource = `
-// This file is auto-generated, DO NOT EDIT.
-//
-// Source:
-//     Title: {{.SpecTitle}}
-//     Version: {{.SpecVersion}}
-package {{ .PackageName }}
-
-{{ (printf "%s is an enum. %s" .Name .Description) | commentBlock }}
-const {{.Name}} = {{ (index .Properties 0).Value}}
-`
-
-var fmap = template.FuncMap{
-	"firstLower":   tpl.FirstLower,
-	"firstUpper":   tpl.FirstUpper,
-	"commentBlock": tpl.CommentBlock,
-	"toPascalCase": tpl.ToPascalCase,
-	"toSnakeCase":  tpl.ToSnakeCase,
-}
-
-var modelTemplate = template.Must(
-	template.New("model").
-		Funcs(fmap).
-		Parse(modelTemplateSource),
-)
-var enumTemplate = template.Must(
-	template.New("enum").
-		Funcs(fmap).
-		Parse(enumTemplateSource),
-)
-var constTemplate = template.Must(
-	template.New("const").
-		Funcs(fmap).
-		Parse(constTemplateSource),
-)
 
 func uniqueStrings(input []string) (output []string) {
 	m := make(map[string]struct{})

--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -11,6 +11,7 @@ import (
 	tpl "github.com/contiamo/openapi-generator-go/pkg/generators/templates"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 )
 
 type ModelKind string
@@ -220,6 +221,10 @@ func fillValidationRelatedStuff(ref *openapi3.SchemaRef, spec *PropSpec) (import
 	case "ip":
 		spec.IsIP = true
 		imports = append(imports, "github.com/go-ozzo/ozzo-validation/v4/is")
+	case "":
+		break // do nothing
+	default:
+		log.Warn().Str("format", ref.Value.Format).Msg("unknown format")
 	}
 	return imports
 }
@@ -281,7 +286,6 @@ func (m {{$modelName}}) Validate() error {
 		{{- range .Properties}}
 		"{{ firstLower .Name }}": validation.Validate(
 			m.{{ .Name }},
-			{{- if .IsRequired }}validation.Required,{{ end }}
 			{{- if .HasMin }}validation.Min({{ .GoType }}({{ .Min }})),{{ end }}
 			{{- if .HasMax }}validation.Max({{ .GoType }}({{ .Max }})),{{ end }}
 			{{- if or .HasMinLength .HasMaxLength }}validation.Length({{ .MinLength }},{{ .MaxLength }}),{{ end }}

--- a/pkg/generators/models/models_test.go
+++ b/pkg/generators/models/models_test.go
@@ -108,7 +108,6 @@ func TestModels(t *testing.T) {
 			}
 		})
 	}
-	t.Fail()
 }
 
 func equalFiles(t *testing.T, expected, actual string) {

--- a/pkg/generators/models/models_test.go
+++ b/pkg/generators/models/models_test.go
@@ -20,6 +20,10 @@ func TestModels(t *testing.T) {
 			directory: "testdata/cases/simple_model",
 		},
 		{
+			name:      "validation",
+			directory: "testdata/cases/validation",
+		},
+		{
 			name:      "embedded type",
 			directory: "testdata/cases/embedded_type",
 		},

--- a/pkg/generators/models/models_test.go
+++ b/pkg/generators/models/models_test.go
@@ -108,6 +108,7 @@ func TestModels(t *testing.T) {
 			}
 		})
 	}
+	t.Fail()
 }
 
 func equalFiles(t *testing.T, expected, actual string) {

--- a/pkg/generators/models/templates.go
+++ b/pkg/generators/models/templates.go
@@ -66,6 +66,7 @@ func (m {{$modelName}}) Validate() error {
 		{{- range .Properties}}
 		"{{ firstLower .Name }}": validation.Validate(
 			m.{{ .Name }},
+			{{- if .IsRequiredInValidation}}validation.Required,{{ end }}
 			{{- if .HasMin }}validation.Min({{ .GoType }}({{ .Min }})),{{ end }}
 			{{- if .HasMax }}validation.Max({{ .GoType }}({{ .Max }})),{{ end }}
 			{{- if or .HasMinLength .HasMaxLength }}validation.Length({{ .MinLength }},{{ .MaxLength }}),{{ end }}

--- a/pkg/generators/models/templates.go
+++ b/pkg/generators/models/templates.go
@@ -73,7 +73,7 @@ func (m {{$modelName}}) Validate() error {
 			{{- if .IsDate }}validation.Date("2006-01-02"),{{ end }}
 			{{- if .IsDateTime }}validation.Date(time.RFC3339),{{ end }}
 			{{- if .IsBase64 }}is.Base64,{{ end }}
-			{{- if .IsEmail }}is.Email,{{ end }}
+			{{- if .IsEmail }}is.EmailFormat,{{ end }}
 			{{- if .IsUUID }}is.UUID,{{ end }}
 			{{- if .IsURL }}is.RequestURL,{{ end }}
 			{{- if .IsHostname }}is.Host,{{ end }}
@@ -111,7 +111,7 @@ import (
 {{ (printf "%s is an enum. %s" .Name .Description) | commentBlock }}
 type {{.Name}} {{.GoType}}
 
-(
+var (
 	{{- $enum :=. }}
 	{{- range $v := .Properties }}
 	{{$enum.Name}}{{$v.Name}} {{$enum.Name}} = {{$v.Value}}

--- a/pkg/generators/models/templates.go
+++ b/pkg/generators/models/templates.go
@@ -1,0 +1,155 @@
+package models
+
+import (
+	"text/template"
+
+	tpl "github.com/contiamo/openapi-generator-go/pkg/generators/templates"
+)
+
+var (
+	modelTemplate = template.Must(
+		template.New("model").
+			Funcs(fmap).
+			Parse(modelTemplateSource),
+	)
+
+	enumTemplate = template.Must(
+		template.New("enum").
+			Funcs(fmap).
+			Parse(enumTemplateSource),
+	)
+
+	constTemplate = template.Must(
+		template.New("const").
+			Funcs(fmap).
+			Parse(constTemplateSource),
+	)
+
+	fmap = template.FuncMap{
+		"firstLower":   tpl.FirstLower,
+		"firstUpper":   tpl.FirstUpper,
+		"commentBlock": tpl.CommentBlock,
+		"toPascalCase": tpl.ToPascalCase,
+		"toSnakeCase":  tpl.ToSnakeCase,
+	}
+
+	modelTemplateSource = `// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: {{.SpecTitle}}
+//     Version: {{.SpecVersion}}
+package {{ .PackageName }}
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+{{- range .Imports}}
+	"{{.}}"
+{{ end}}
+)
+
+{{ (printf "%s is an object. %s" .Name .Description) | commentBlock }}
+{{- if not .Properties }}
+type {{.Name}} map[string]interface{}
+{{- else }}
+type {{.Name}} struct {
+{{- range .Properties}}
+	{{ (printf "%s: %s" .Name .Description) | commentBlock }}
+	{{.Name}} {{.GoType}} {{.JSONTags}}
+{{- end}}
+}
+{{- end}}
+
+{{- $modelName := .Name }}
+// Validate implements basic validation for this model
+func (m {{$modelName}}) Validate() error {
+	return validation.Errors{
+		{{- range .Properties}}
+		"{{ firstLower .Name }}": validation.Validate(
+			m.{{ .Name }},
+			{{- if .HasMin }}validation.Min({{ .GoType }}({{ .Min }})),{{ end }}
+			{{- if .HasMax }}validation.Max({{ .GoType }}({{ .Max }})),{{ end }}
+			{{- if or .HasMinLength .HasMaxLength }}validation.Length({{ .MinLength }},{{ .MaxLength }}),{{ end }}
+			{{- if .IsEnum }}InKnown{{ .GoType }},{{ end }}
+			{{- if .IsDate }}validation.Date("2006-01-02"),{{ end }}
+			{{- if .IsDateTime }}validation.Date(time.RFC3339),{{ end }}
+			{{- if .IsBase64 }}is.Base64,{{ end }}
+			{{- if .IsEmail }}is.Email,{{ end }}
+			{{- if .IsUUID }}is.UUID,{{ end }}
+			{{- if .IsURL }}is.RequestURL,{{ end }}
+			{{- if .IsHostname }}is.Host,{{ end }}
+			{{- if .IsIPv4 }}is.IPv4,{{ end }}
+			{{- if .IsIPv6 }}is.IPv6,{{ end }}
+			{{- if .IsIP }}is.IP,{{ end }}
+		),
+	{{- end }}
+	}.Filter()
+}
+{{ range .Properties}}
+// Get{{.Name}} returns the {{.Name}} property
+func (m {{$modelName}}) Get{{.Name}}() {{.GoType}} {
+	return m.{{.Name}}
+}
+
+// Set{{.Name}} sets the {{.Name}} property
+func (m {{$modelName}}) Set{{.Name}}(val {{.GoType}}) {
+	m.{{.Name}} = val
+}
+{{ end}}`
+
+	enumTemplateSource = `
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: {{.SpecTitle}}
+//     Version: {{.SpecVersion}}
+package {{ .PackageName }}
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+{{ (printf "%s is an enum. %s" .Name .Description) | commentBlock }}
+type {{.Name}} {{.GoType}}
+
+(
+	{{- $enum :=. }}
+	{{- range $v := .Properties }}
+	{{$enum.Name}}{{$v.Name}} {{$enum.Name}} = {{$v.Value}}
+	{{- end}}
+
+	// Known{{.Name}} is the list of valid {{.Name}}
+	Known{{.Name }} = []{{.Name}}{
+		{{- range $v := .Properties }}
+		{{$enum.Name}}{{$v.Name}},
+		{{- end}}
+	}
+
+	{{- $enum :=. }}
+	// Known{{$enum.Name}}{{$enum.GoType | firstUpper}} is the list of valid {{$enum.Name}} as {{$enum.GoType}}
+	Known{{$enum.Name}}{{$enum.GoType | firstUpper}} = []{{$enum.GoType}}{
+		{{- range $v := .Properties }}
+		{{$enum.GoType}}({{$enum.Name}}{{$v.Name}}),
+		{{- end}}
+	}
+
+	// InKnown{{.Name}} is an ozzo-validator for {{.Name}}
+	InKnown{{.Name}} = validation.In(
+		{{- range $v := .Properties }}
+		{{$enum.Name}}{{$v.Name}},
+		{{- end}}
+	)
+)
+`
+
+	constTemplateSource = `
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: {{.SpecTitle}}
+//     Version: {{.SpecVersion}}
+package {{ .PackageName }}
+
+{{ (printf "%s is an enum. %s" .Name .Description) | commentBlock }}
+const {{.Name}} = {{ (index .Properties 0).Value}}
+`
+)

--- a/pkg/generators/models/templates.go
+++ b/pkg/generators/models/templates.go
@@ -64,25 +64,27 @@ type {{.Name}} struct {
 func (m {{$modelName}}) Validate() error {
 	return validation.Errors{
 		{{- range .Properties}}
-		"{{ firstLower .Name }}": validation.Validate(
-			m.{{ .Name }},
-			{{- if .IsRequiredInValidation}}validation.Required,{{ end }}
-			{{- if .HasMin }}validation.Min({{ .GoType }}({{ .Min }})),{{ end }}
-			{{- if .HasMax }}validation.Max({{ .GoType }}({{ .Max }})),{{ end }}
-			{{- if or .HasMinLength .HasMaxLength }}validation.Length({{ .MinLength }},{{ .MaxLength }}),{{ end }}
-			{{- if .IsEnum }}InKnown{{ .GoType }},{{ end }}
-			{{- if .IsDate }}validation.Date("2006-01-02"),{{ end }}
-			{{- if .IsDateTime }}validation.Date(time.RFC3339),{{ end }}
-			{{- if .IsBase64 }}is.Base64,{{ end }}
-			{{- if .IsEmail }}is.EmailFormat,{{ end }}
-			{{- if .IsUUID }}is.UUID,{{ end }}
-			{{- if .IsURL }}is.RequestURL,{{ end }}
-			{{- if .IsHostname }}is.Host,{{ end }}
-			{{- if .IsIPv4 }}is.IPv4,{{ end }}
-			{{- if .IsIPv6 }}is.IPv6,{{ end }}
-			{{- if .IsIP }}is.IP,{{ end }}
-		),
-	{{- end }}
+			{{- if .NeedsValidation }}
+				"{{ firstLower .Name }}": validation.Validate(
+					m.{{ .Name }},
+					{{- if .IsRequiredInValidation}}validation.Required,{{ end }}
+					{{- if .HasMin }}validation.Min({{ .GoType }}({{ .Min }})),{{ end }}
+					{{- if .HasMax }}validation.Max({{ .GoType }}({{ .Max }})),{{ end }}
+					{{- if or .HasMinLength .HasMaxLength }}validation.Length({{ .MinLength }},{{ .MaxLength }}),{{ end }}
+					{{- if .IsEnum }}InKnown{{ .GoType }},{{ end }}
+					{{- if .IsDate }}validation.Date("2006-01-02"),{{ end }}
+					{{- if .IsDateTime }}validation.Date(time.RFC3339),{{ end }}
+					{{- if .IsBase64 }}is.Base64,{{ end }}
+					{{- if .IsEmail }}is.EmailFormat,{{ end }}
+					{{- if .IsUUID }}is.UUID,{{ end }}
+					{{- if .IsURL }}is.RequestURL,{{ end }}
+					{{- if .IsHostname }}is.Host,{{ end }}
+					{{- if .IsIPv4 }}is.IPv4,{{ end }}
+					{{- if .IsIPv6 }}is.IPv6,{{ end }}
+					{{- if .IsIP }}is.IP,{{ end }}
+				),
+			{{- end }}
+		{{- end }}
 	}.Filter()
 }
 {{ range .Properties}}

--- a/pkg/generators/models/templates.go
+++ b/pkg/generators/models/templates.go
@@ -71,7 +71,6 @@ func (m {{$modelName}}) Validate() error {
 					{{- if .HasMin }}validation.Min({{ .GoType }}({{ .Min }})),{{ end }}
 					{{- if .HasMax }}validation.Max({{ .GoType }}({{ .Max }})),{{ end }}
 					{{- if or .HasMinLength .HasMaxLength }}validation.Length({{ .MinLength }},{{ .MaxLength }}),{{ end }}
-					{{- if .IsEnum }}InKnown{{ .GoType }},{{ end }}
 					{{- if .IsDate }}validation.Date("2006-01-02"),{{ end }}
 					{{- if .IsDateTime }}validation.Date(time.RFC3339),{{ end }}
 					{{- if .IsBase64 }}is.Base64,{{ end }}
@@ -113,6 +112,11 @@ import (
 
 {{ (printf "%s is an enum. %s" .Name .Description) | commentBlock }}
 type {{.Name}} {{.GoType}}
+
+// Validate implements basic validation for this model
+func (m {{.Name}}) Validate() error {
+	return InKnown{{.Name}}.Validate(m)
+}
 
 var (
 	{{- $enum :=. }}

--- a/pkg/generators/models/testdata/cases/allof1/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof1/expected/model_foo.go
@@ -20,11 +20,7 @@ type Foo struct {
 
 // Validate implements basic validation for this model
 func (m Foo) Validate() error {
-	return validation.Errors{
-		"bar": validation.Validate(
-			m.Bar,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/allof1/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof1/expected/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/allof1/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof1/expected/model_foo.go
@@ -5,6 +5,10 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
@@ -12,6 +16,15 @@ type Foo struct {
 		Bar string `json:"bar,omitempty"`
 		Foo string `json:"foo,omitempty"`
 	} `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/allof1/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof1/generated/model_foo.go
@@ -20,11 +20,7 @@ type Foo struct {
 
 // Validate implements basic validation for this model
 func (m Foo) Validate() error {
-	return validation.Errors{
-		"bar": validation.Validate(
-			m.Bar,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/allof1/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof1/generated/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/allof1/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof1/generated/model_foo.go
@@ -5,6 +5,10 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
@@ -12,6 +16,15 @@ type Foo struct {
 		Bar string `json:"bar,omitempty"`
 		Foo string `json:"foo,omitempty"`
 	} `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/allof2/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof2/expected/model_foo.go
@@ -19,14 +19,7 @@ type Foo struct {
 
 // Validate implements basic validation for this model
 func (m Foo) Validate() error {
-	return validation.Errors{
-		"bar": validation.Validate(
-			m.Bar,
-		),
-		"foo": validation.Validate(
-			m.Foo,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/allof2/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof2/expected/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/allof2/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof2/expected/model_foo.go
@@ -5,12 +5,28 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar string `json:"bar,omitempty"`
 	// Foo:
 	Foo string `json:"foo,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+		"foo": validation.Validate(
+			m.Foo,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/allof2/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof2/generated/model_foo.go
@@ -19,14 +19,7 @@ type Foo struct {
 
 // Validate implements basic validation for this model
 func (m Foo) Validate() error {
-	return validation.Errors{
-		"bar": validation.Validate(
-			m.Bar,
-		),
-		"foo": validation.Validate(
-			m.Foo,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/allof2/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof2/generated/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/allof2/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof2/generated/model_foo.go
@@ -5,12 +5,28 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar string `json:"bar,omitempty"`
 	// Foo:
 	Foo string `json:"foo,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+		"foo": validation.Validate(
+			m.Foo,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/allof3/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof3/expected/model_foo.go
@@ -5,12 +5,28 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Mixin:
 	Mixin string `json:"mixin,omitempty"`
 	// Sub:
 	Sub string `json:"sub,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"mixin": validation.Validate(
+			m.Mixin,
+		),
+		"sub": validation.Validate(
+			m.Sub,
+		),
+	}.Filter()
 }
 
 // GetMixin returns the Mixin property

--- a/pkg/generators/models/testdata/cases/allof3/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof3/expected/model_foo.go
@@ -19,14 +19,7 @@ type Foo struct {
 
 // Validate implements basic validation for this model
 func (m Foo) Validate() error {
-	return validation.Errors{
-		"mixin": validation.Validate(
-			m.Mixin,
-		),
-		"sub": validation.Validate(
-			m.Sub,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetMixin returns the Mixin property

--- a/pkg/generators/models/testdata/cases/allof3/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof3/expected/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/allof3/expected/model_sub.go
+++ b/pkg/generators/models/testdata/cases/allof3/expected/model_sub.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Sub is an object.
 type Sub struct {
 	// Sub:
 	Sub string `json:"sub,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Sub) Validate() error {
+	return validation.Errors{
+		"sub": validation.Validate(
+			m.Sub,
+		),
+	}.Filter()
 }
 
 // GetSub returns the Sub property

--- a/pkg/generators/models/testdata/cases/allof3/expected/model_sub.go
+++ b/pkg/generators/models/testdata/cases/allof3/expected/model_sub.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Sub is an object.

--- a/pkg/generators/models/testdata/cases/allof3/expected/model_sub.go
+++ b/pkg/generators/models/testdata/cases/allof3/expected/model_sub.go
@@ -17,11 +17,7 @@ type Sub struct {
 
 // Validate implements basic validation for this model
 func (m Sub) Validate() error {
-	return validation.Errors{
-		"sub": validation.Validate(
-			m.Sub,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetSub returns the Sub property

--- a/pkg/generators/models/testdata/cases/allof3/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof3/generated/model_foo.go
@@ -5,12 +5,28 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Mixin:
 	Mixin string `json:"mixin,omitempty"`
 	// Sub:
 	Sub string `json:"sub,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"mixin": validation.Validate(
+			m.Mixin,
+		),
+		"sub": validation.Validate(
+			m.Sub,
+		),
+	}.Filter()
 }
 
 // GetMixin returns the Mixin property

--- a/pkg/generators/models/testdata/cases/allof3/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof3/generated/model_foo.go
@@ -19,14 +19,7 @@ type Foo struct {
 
 // Validate implements basic validation for this model
 func (m Foo) Validate() error {
-	return validation.Errors{
-		"mixin": validation.Validate(
-			m.Mixin,
-		),
-		"sub": validation.Validate(
-			m.Sub,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetMixin returns the Mixin property

--- a/pkg/generators/models/testdata/cases/allof3/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof3/generated/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/allof3/generated/model_sub.go
+++ b/pkg/generators/models/testdata/cases/allof3/generated/model_sub.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Sub is an object.
 type Sub struct {
 	// Sub:
 	Sub string `json:"sub,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Sub) Validate() error {
+	return validation.Errors{
+		"sub": validation.Validate(
+			m.Sub,
+		),
+	}.Filter()
 }
 
 // GetSub returns the Sub property

--- a/pkg/generators/models/testdata/cases/allof3/generated/model_sub.go
+++ b/pkg/generators/models/testdata/cases/allof3/generated/model_sub.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Sub is an object.

--- a/pkg/generators/models/testdata/cases/allof3/generated/model_sub.go
+++ b/pkg/generators/models/testdata/cases/allof3/generated/model_sub.go
@@ -17,11 +17,7 @@ type Sub struct {
 
 // Validate implements basic validation for this model
 func (m Sub) Validate() error {
-	return validation.Errors{
-		"sub": validation.Validate(
-			m.Sub,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetSub returns the Sub property

--- a/pkg/generators/models/testdata/cases/allof4/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof4/expected/model_foo.go
@@ -17,11 +17,7 @@ type Foo struct {
 
 // Validate implements basic validation for this model
 func (m Foo) Validate() error {
-	return validation.Errors{
-		"bar": validation.Validate(
-			m.Bar,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/allof4/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof4/expected/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar *Sub `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/allof4/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof4/expected/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/allof4/expected/model_sub.go
+++ b/pkg/generators/models/testdata/cases/allof4/expected/model_sub.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Sub is an object.
 type Sub struct {
 	// Sub:
 	Sub string `json:"sub,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Sub) Validate() error {
+	return validation.Errors{
+		"sub": validation.Validate(
+			m.Sub,
+		),
+	}.Filter()
 }
 
 // GetSub returns the Sub property

--- a/pkg/generators/models/testdata/cases/allof4/expected/model_sub.go
+++ b/pkg/generators/models/testdata/cases/allof4/expected/model_sub.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Sub is an object.

--- a/pkg/generators/models/testdata/cases/allof4/expected/model_sub.go
+++ b/pkg/generators/models/testdata/cases/allof4/expected/model_sub.go
@@ -17,11 +17,7 @@ type Sub struct {
 
 // Validate implements basic validation for this model
 func (m Sub) Validate() error {
-	return validation.Errors{
-		"sub": validation.Validate(
-			m.Sub,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetSub returns the Sub property

--- a/pkg/generators/models/testdata/cases/allof4/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof4/generated/model_foo.go
@@ -17,11 +17,7 @@ type Foo struct {
 
 // Validate implements basic validation for this model
 func (m Foo) Validate() error {
-	return validation.Errors{
-		"bar": validation.Validate(
-			m.Bar,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/allof4/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof4/generated/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar *Sub `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/allof4/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof4/generated/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/allof4/generated/model_sub.go
+++ b/pkg/generators/models/testdata/cases/allof4/generated/model_sub.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Sub is an object.
 type Sub struct {
 	// Sub:
 	Sub string `json:"sub,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Sub) Validate() error {
+	return validation.Errors{
+		"sub": validation.Validate(
+			m.Sub,
+		),
+	}.Filter()
 }
 
 // GetSub returns the Sub property

--- a/pkg/generators/models/testdata/cases/allof4/generated/model_sub.go
+++ b/pkg/generators/models/testdata/cases/allof4/generated/model_sub.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Sub is an object.

--- a/pkg/generators/models/testdata/cases/allof4/generated/model_sub.go
+++ b/pkg/generators/models/testdata/cases/allof4/generated/model_sub.go
@@ -17,11 +17,7 @@ type Sub struct {
 
 // Validate implements basic validation for this model
 func (m Sub) Validate() error {
-	return validation.Errors{
-		"sub": validation.Validate(
-			m.Sub,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetSub returns the Sub property

--- a/pkg/generators/models/testdata/cases/embedded_type/expected/model_sub.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/expected/model_sub.go
@@ -17,11 +17,7 @@ type Sub struct {
 
 // Validate implements basic validation for this model
 func (m Sub) Validate() error {
-	return validation.Errors{
-		"foo": validation.Validate(
-			m.Foo,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetFoo returns the Foo property

--- a/pkg/generators/models/testdata/cases/embedded_type/expected/model_sub.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/expected/model_sub.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Sub is an object.
 type Sub struct {
 	// Foo:
 	Foo string `json:"foo,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Sub) Validate() error {
+	return validation.Errors{
+		"foo": validation.Validate(
+			m.Foo,
+		),
+	}.Filter()
 }
 
 // GetFoo returns the Foo property

--- a/pkg/generators/models/testdata/cases/embedded_type/expected/model_sub.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/expected/model_sub.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Sub is an object.

--- a/pkg/generators/models/testdata/cases/embedded_type/expected/model_top.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/expected/model_top.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Top is an object.

--- a/pkg/generators/models/testdata/cases/embedded_type/expected/model_top.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/expected/model_top.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Top is an object.
 type Top struct {
 	// Bar:
 	Bar Sub `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Top) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/embedded_type/expected/model_top.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/expected/model_top.go
@@ -19,7 +19,7 @@ type Top struct {
 func (m Top) Validate() error {
 	return validation.Errors{
 		"bar": validation.Validate(
-			m.Bar, validation.Required,
+			m.Bar,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/embedded_type/expected/model_top.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/expected/model_top.go
@@ -19,7 +19,7 @@ type Top struct {
 func (m Top) Validate() error {
 	return validation.Errors{
 		"bar": validation.Validate(
-			m.Bar,
+			m.Bar, validation.Required,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/embedded_type/generated/model_sub.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/generated/model_sub.go
@@ -17,11 +17,7 @@ type Sub struct {
 
 // Validate implements basic validation for this model
 func (m Sub) Validate() error {
-	return validation.Errors{
-		"foo": validation.Validate(
-			m.Foo,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetFoo returns the Foo property

--- a/pkg/generators/models/testdata/cases/embedded_type/generated/model_sub.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/generated/model_sub.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Sub is an object.
 type Sub struct {
 	// Foo:
 	Foo string `json:"foo,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Sub) Validate() error {
+	return validation.Errors{
+		"foo": validation.Validate(
+			m.Foo,
+		),
+	}.Filter()
 }
 
 // GetFoo returns the Foo property

--- a/pkg/generators/models/testdata/cases/embedded_type/generated/model_sub.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/generated/model_sub.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Sub is an object.

--- a/pkg/generators/models/testdata/cases/embedded_type/generated/model_top.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/generated/model_top.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Top is an object.

--- a/pkg/generators/models/testdata/cases/embedded_type/generated/model_top.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/generated/model_top.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Top is an object.
 type Top struct {
 	// Bar:
 	Bar Sub `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Top) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/embedded_type/generated/model_top.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/generated/model_top.go
@@ -19,7 +19,7 @@ type Top struct {
 func (m Top) Validate() error {
 	return validation.Errors{
 		"bar": validation.Validate(
-			m.Bar, validation.Required,
+			m.Bar,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/embedded_type/generated/model_top.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/generated/model_top.go
@@ -19,7 +19,7 @@ type Top struct {
 func (m Top) Validate() error {
 	return validation.Errors{
 		"bar": validation.Validate(
-			m.Bar,
+			m.Bar, validation.Required,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/enum/expected/model_name.go
+++ b/pkg/generators/models/testdata/cases/enum/expected/model_name.go
@@ -12,6 +12,11 @@ import (
 // Name is an enum.
 type Name string
 
+// Validate implements basic validation for this model
+func (m Name) Validate() error {
+	return InKnownName.Validate(m)
+}
+
 var (
 	NameBar Name = "bar"
 	NameFoo Name = "foo"

--- a/pkg/generators/models/testdata/cases/enum/expected/model_name.go
+++ b/pkg/generators/models/testdata/cases/enum/expected/model_name.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Name is an enum.

--- a/pkg/generators/models/testdata/cases/enum/generated/model_name.go
+++ b/pkg/generators/models/testdata/cases/enum/generated/model_name.go
@@ -12,6 +12,11 @@ import (
 // Name is an enum.
 type Name string
 
+// Validate implements basic validation for this model
+func (m Name) Validate() error {
+	return InKnownName.Validate(m)
+}
+
 var (
 	NameBar Name = "bar"
 	NameFoo Name = "foo"

--- a/pkg/generators/models/testdata/cases/enum/generated/model_name.go
+++ b/pkg/generators/models/testdata/cases/enum/generated/model_name.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Name is an enum.

--- a/pkg/generators/models/testdata/cases/nullable_arrays/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_arrays/expected/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/nullable_arrays/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_arrays/expected/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar []string `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/nullable_arrays/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_arrays/generated/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/nullable_arrays/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_arrays/generated/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar []string `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/nullable_properties/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_properties/expected/model_foo.go
@@ -17,11 +17,7 @@ type Foo struct {
 
 // Validate implements basic validation for this model
 func (m Foo) Validate() error {
-	return validation.Errors{
-		"bar": validation.Validate(
-			m.Bar,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/nullable_properties/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_properties/expected/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar *string `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/nullable_properties/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_properties/expected/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/nullable_properties/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_properties/generated/model_foo.go
@@ -17,11 +17,7 @@ type Foo struct {
 
 // Validate implements basic validation for this model
 func (m Foo) Validate() error {
-	return validation.Errors{
-		"bar": validation.Validate(
-			m.Bar,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/nullable_properties/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_properties/generated/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar *string `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/nullable_properties/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_properties/generated/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/nullable_untyped_object/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_untyped_object/expected/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar map[string]interface{} `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/nullable_untyped_object/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_untyped_object/expected/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/nullable_untyped_object/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_untyped_object/generated/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar map[string]interface{} `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/nullable_untyped_object/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_untyped_object/generated/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/object_with_additional_properties/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/object_with_additional_properties/expected/model_foo.go
@@ -19,7 +19,7 @@ type Foo struct {
 func (m Foo) Validate() error {
 	return validation.Errors{
 		"foo": validation.Validate(
-			m.Foo,
+			m.Foo, validation.Required,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/object_with_additional_properties/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/object_with_additional_properties/expected/model_foo.go
@@ -19,7 +19,7 @@ type Foo struct {
 func (m Foo) Validate() error {
 	return validation.Errors{
 		"foo": validation.Validate(
-			m.Foo, validation.Required,
+			m.Foo,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/object_with_additional_properties/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/object_with_additional_properties/expected/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/object_with_additional_properties/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/object_with_additional_properties/expected/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Foo:
 	Foo map[string]string `json:"foo,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"foo": validation.Validate(
+			m.Foo,
+		),
+	}.Filter()
 }
 
 // GetFoo returns the Foo property

--- a/pkg/generators/models/testdata/cases/object_with_additional_properties/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/object_with_additional_properties/generated/model_foo.go
@@ -19,7 +19,7 @@ type Foo struct {
 func (m Foo) Validate() error {
 	return validation.Errors{
 		"foo": validation.Validate(
-			m.Foo,
+			m.Foo, validation.Required,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/object_with_additional_properties/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/object_with_additional_properties/generated/model_foo.go
@@ -19,7 +19,7 @@ type Foo struct {
 func (m Foo) Validate() error {
 	return validation.Errors{
 		"foo": validation.Validate(
-			m.Foo, validation.Required,
+			m.Foo,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/object_with_additional_properties/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/object_with_additional_properties/generated/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/object_with_additional_properties/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/object_with_additional_properties/generated/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Foo:
 	Foo map[string]string `json:"foo,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"foo": validation.Validate(
+			m.Foo,
+		),
+	}.Filter()
 }
 
 // GetFoo returns the Foo property

--- a/pkg/generators/models/testdata/cases/oneof/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/oneof/expected/model_foo.go
@@ -17,11 +17,7 @@ type Foo struct {
 
 // Validate implements basic validation for this model
 func (m Foo) Validate() error {
-	return validation.Errors{
-		"bar": validation.Validate(
-			m.Bar,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/oneof/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/oneof/expected/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/oneof/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/oneof/expected/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar interface{} `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/oneof/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/oneof/generated/model_foo.go
@@ -17,11 +17,7 @@ type Foo struct {
 
 // Validate implements basic validation for this model
 func (m Foo) Validate() error {
-	return validation.Errors{
-		"bar": validation.Validate(
-			m.Bar,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/oneof/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/oneof/generated/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/oneof/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/oneof/generated/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar interface{} `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/required_properties/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/required_properties/expected/model_foo.go
@@ -17,11 +17,7 @@ type Foo struct {
 
 // Validate implements basic validation for this model
 func (m Foo) Validate() error {
-	return validation.Errors{
-		"bar": validation.Validate(
-			m.Bar,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/required_properties/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/required_properties/expected/model_foo.go
@@ -19,7 +19,7 @@ type Foo struct {
 func (m Foo) Validate() error {
 	return validation.Errors{
 		"bar": validation.Validate(
-			m.Bar, validation.Required,
+			m.Bar,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/required_properties/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/required_properties/expected/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/required_properties/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/required_properties/expected/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar string `json:"bar"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar, validation.Required,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/required_properties/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/required_properties/generated/model_foo.go
@@ -17,11 +17,7 @@ type Foo struct {
 
 // Validate implements basic validation for this model
 func (m Foo) Validate() error {
-	return validation.Errors{
-		"bar": validation.Validate(
-			m.Bar,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/required_properties/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/required_properties/generated/model_foo.go
@@ -19,7 +19,7 @@ type Foo struct {
 func (m Foo) Validate() error {
 	return validation.Errors{
 		"bar": validation.Validate(
-			m.Bar, validation.Required,
+			m.Bar,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/required_properties/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/required_properties/generated/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/required_properties/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/required_properties/generated/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar string `json:"bar"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar, validation.Required,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/simple_model/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/simple_model/expected/model_foo.go
@@ -17,11 +17,7 @@ type Foo struct {
 
 // Validate implements basic validation for this model
 func (m Foo) Validate() error {
-	return validation.Errors{
-		"bar": validation.Validate(
-			m.Bar,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/simple_model/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/simple_model/expected/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/simple_model/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/simple_model/expected/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar string `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/simple_model/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/simple_model/generated/model_foo.go
@@ -17,11 +17,7 @@ type Foo struct {
 
 // Validate implements basic validation for this model
 func (m Foo) Validate() error {
-	return validation.Errors{
-		"bar": validation.Validate(
-			m.Bar,
-		),
-	}.Filter()
+	return validation.Errors{}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/simple_model/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/simple_model/generated/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/simple_model/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/simple_model/generated/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar string `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/typed_arrays/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/typed_arrays/expected/model_foo.go
@@ -19,7 +19,7 @@ type Foo struct {
 func (m Foo) Validate() error {
 	return validation.Errors{
 		"bar": validation.Validate(
-			m.Bar, validation.Required,
+			m.Bar,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/typed_arrays/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/typed_arrays/expected/model_foo.go
@@ -19,7 +19,7 @@ type Foo struct {
 func (m Foo) Validate() error {
 	return validation.Errors{
 		"bar": validation.Validate(
-			m.Bar,
+			m.Bar, validation.Required,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/typed_arrays/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/typed_arrays/expected/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/typed_arrays/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/typed_arrays/expected/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar []string `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/typed_arrays/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/typed_arrays/generated/model_foo.go
@@ -19,7 +19,7 @@ type Foo struct {
 func (m Foo) Validate() error {
 	return validation.Errors{
 		"bar": validation.Validate(
-			m.Bar, validation.Required,
+			m.Bar,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/typed_arrays/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/typed_arrays/generated/model_foo.go
@@ -19,7 +19,7 @@ type Foo struct {
 func (m Foo) Validate() error {
 	return validation.Errors{
 		"bar": validation.Validate(
-			m.Bar,
+			m.Bar, validation.Required,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/typed_arrays/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/typed_arrays/generated/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/typed_arrays/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/typed_arrays/generated/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar []string `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/untyped_object/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/untyped_object/expected/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar map[string]interface{} `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/untyped_object/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/untyped_object/expected/model_foo.go
@@ -19,7 +19,7 @@ type Foo struct {
 func (m Foo) Validate() error {
 	return validation.Errors{
 		"bar": validation.Validate(
-			m.Bar, validation.Required,
+			m.Bar,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/untyped_object/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/untyped_object/expected/model_foo.go
@@ -19,7 +19,7 @@ type Foo struct {
 func (m Foo) Validate() error {
 	return validation.Errors{
 		"bar": validation.Validate(
-			m.Bar,
+			m.Bar, validation.Required,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/untyped_object/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/untyped_object/expected/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/untyped_object/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/untyped_object/generated/model_foo.go
@@ -5,10 +5,23 @@
 //     Version: 0.1.0
 package generatortest
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
 // Foo is an object.
 type Foo struct {
 	// Bar:
 	Bar map[string]interface{} `json:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
 }
 
 // GetBar returns the Bar property

--- a/pkg/generators/models/testdata/cases/untyped_object/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/untyped_object/generated/model_foo.go
@@ -19,7 +19,7 @@ type Foo struct {
 func (m Foo) Validate() error {
 	return validation.Errors{
 		"bar": validation.Validate(
-			m.Bar, validation.Required,
+			m.Bar,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/untyped_object/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/untyped_object/generated/model_foo.go
@@ -19,7 +19,7 @@ type Foo struct {
 func (m Foo) Validate() error {
 	return validation.Errors{
 		"bar": validation.Validate(
-			m.Bar,
+			m.Bar, validation.Required,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/untyped_object/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/untyped_object/generated/model_foo.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Foo is an object.

--- a/pkg/generators/models/testdata/cases/validation/api.yaml
+++ b/pkg/generators/models/testdata/cases/validation/api.yaml
@@ -17,10 +17,43 @@ components:
           maxLength: 32
         age:
           type: number
-          minimum: 0
+          minimum: 18
           maximum: 120
         gender:
           $ref: "#/components/schemas/Gender"
+        email:
+          type: string
+          format: email
+        date:
+          type: string
+          format: "date"
+        datetime:
+          type: string
+          format: "date-time"
+        base64:
+          type: string
+          format: "base64"
+        email:
+          type: string
+          format: "email"
+        uuid:
+          type: string
+          format: "uuid"
+        url:
+          type: string
+          format: "url"
+        hostname:
+          type: string
+          format: "hostname"
+        ipv4:
+          type: string
+          format: "ipv4"
+        ipv6:
+          type: string
+          format: "ipv6"
+        ip:
+          type: string
+          format: "ip"
     Gender:
       type: string
       enum:

--- a/pkg/generators/models/testdata/cases/validation/api.yaml
+++ b/pkg/generators/models/testdata/cases/validation/api.yaml
@@ -21,6 +21,13 @@ components:
           maximum: 120
         gender:
           $ref: "#/components/schemas/Gender"
+        address:
+          $ref: "#/components/schemas/Address"
+        favoriteColors:
+          type: array
+          items:
+            $ref: "#/components/schemas/Color"
+          minLength: 1
         email:
           type: string
           format: email
@@ -60,3 +67,26 @@ components:
         - default
         - female
         - male
+    Color:
+      type: string
+      enum:
+        - red
+        - blue
+        - green
+        - yellow
+    Address:
+      type: object
+      required:
+        - street
+        - number
+        - name
+      properties:
+        street:
+          type: string
+          minLength: 2
+        number:
+          type: integer
+        name:
+          type: string
+          nullable: true
+          minLength: 2

--- a/pkg/generators/models/testdata/cases/validation/api.yaml
+++ b/pkg/generators/models/testdata/cases/validation/api.yaml
@@ -32,7 +32,7 @@ components:
           format: "date-time"
         base64:
           type: string
-          format: "base64"
+          format: "byte"
         email:
           type: string
           format: "email"

--- a/pkg/generators/models/testdata/cases/validation/api.yaml
+++ b/pkg/generators/models/testdata/cases/validation/api.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  version: 0.1.0
+  title: Test
+
+components:
+  schemas:
+    Person:
+      type: object
+      required:
+        - name
+        - gender
+      properties:
+        name:
+          type: string
+          minLength: 2
+          maxLength: 32
+        age:
+          type: number
+          minimum: 0
+          maximum: 120
+        gender:
+          $ref: "#/components/schemas/Gender"
+    Gender:
+      type: string
+      enum:
+        - default
+        - female
+        - male

--- a/pkg/generators/models/testdata/cases/validation/expected/model_address.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_address.go
@@ -1,0 +1,62 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Address is an object.
+type Address struct {
+	// Name:
+	Name *string `json:"name"`
+	// Number:
+	Number int64 `json:"number"`
+	// Street:
+	Street string `json:"street"`
+}
+
+// Validate implements basic validation for this model
+func (m Address) Validate() error {
+	return validation.Errors{
+		"name": validation.Validate(
+			m.Name, validation.Length(2, 0),
+		),
+		"street": validation.Validate(
+			m.Street, validation.Required, validation.Length(2, 0),
+		),
+	}.Filter()
+}
+
+// GetName returns the Name property
+func (m Address) GetName() *string {
+	return m.Name
+}
+
+// SetName sets the Name property
+func (m Address) SetName(val *string) {
+	m.Name = val
+}
+
+// GetNumber returns the Number property
+func (m Address) GetNumber() int64 {
+	return m.Number
+}
+
+// SetNumber sets the Number property
+func (m Address) SetNumber(val int64) {
+	m.Number = val
+}
+
+// GetStreet returns the Street property
+func (m Address) GetStreet() string {
+	return m.Street
+}
+
+// SetStreet sets the Street property
+func (m Address) SetStreet(val string) {
+	m.Street = val
+}

--- a/pkg/generators/models/testdata/cases/validation/expected/model_color.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_color.go
@@ -1,0 +1,43 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Color is an enum.
+type Color string
+
+var (
+	ColorBlue   Color = "blue"
+	ColorGreen  Color = "green"
+	ColorRed    Color = "red"
+	ColorYellow Color = "yellow"
+
+	// KnownColor is the list of valid Color
+	KnownColor = []Color{
+		ColorBlue,
+		ColorGreen,
+		ColorRed,
+		ColorYellow,
+	}
+	// KnownColorString is the list of valid Color as string
+	KnownColorString = []string{
+		string(ColorBlue),
+		string(ColorGreen),
+		string(ColorRed),
+		string(ColorYellow),
+	}
+
+	// InKnownColor is an ozzo-validator for Color
+	InKnownColor = validation.In(
+		ColorBlue,
+		ColorGreen,
+		ColorRed,
+		ColorYellow,
+	)
+)

--- a/pkg/generators/models/testdata/cases/validation/expected/model_color.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_color.go
@@ -12,6 +12,11 @@ import (
 // Color is an enum.
 type Color string
 
+// Validate implements basic validation for this model
+func (m Color) Validate() error {
+	return InKnownColor.Validate(m)
+}
+
 var (
 	ColorBlue   Color = "blue"
 	ColorGreen  Color = "green"

--- a/pkg/generators/models/testdata/cases/validation/expected/model_gender.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_gender.go
@@ -1,0 +1,39 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
+// Gender is an enum.
+type Gender string
+
+var (
+	GenderDefault Gender = "default"
+	GenderFemale  Gender = "female"
+	GenderMale    Gender = "male"
+
+	// KnownGender is the list of valid Gender
+	KnownGender = []Gender{
+		GenderDefault,
+		GenderFemale,
+		GenderMale,
+	}
+	// KnownGenderString is the list of valid Gender as string
+	KnownGenderString = []string{
+		string(GenderDefault),
+		string(GenderFemale),
+		string(GenderMale),
+	}
+
+	// InKnownGender is an ozzo-validator for Gender
+	InKnownGender = validation.In(
+		GenderDefault,
+		GenderFemale,
+		GenderMale,
+	)
+)

--- a/pkg/generators/models/testdata/cases/validation/expected/model_gender.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_gender.go
@@ -12,6 +12,11 @@ import (
 // Gender is an enum.
 type Gender string
 
+// Validate implements basic validation for this model
+func (m Gender) Validate() error {
+	return InKnownGender.Validate(m)
+}
+
 var (
 	GenderDefault Gender = "default"
 	GenderFemale  Gender = "female"

--- a/pkg/generators/models/testdata/cases/validation/expected/model_gender.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_gender.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Gender is an enum.

--- a/pkg/generators/models/testdata/cases/validation/expected/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_person.go
@@ -7,9 +7,9 @@ package generatortest
 
 import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
-	"time"
-
 	"github.com/go-ozzo/ozzo-validation/v4/is"
+
+	"time"
 )
 
 // Person is an object.
@@ -49,7 +49,7 @@ func (m Person) Validate() error {
 			m.Age, validation.Min(float32(18)), validation.Max(float32(120)),
 		),
 		"base64": validation.Validate(
-			m.Base64,
+			m.Base64, is.Base64,
 		),
 		"date": validation.Validate(
 			m.Date, validation.Date("2006-01-02"),
@@ -61,7 +61,7 @@ func (m Person) Validate() error {
 			m.Email, is.Email,
 		),
 		"gender": validation.Validate(
-			m.Gender, validation.Required, InKnownGender,
+			m.Gender, InKnownGender,
 		),
 		"hostname": validation.Validate(
 			m.Hostname, is.Host,
@@ -76,7 +76,7 @@ func (m Person) Validate() error {
 			m.Ipv6, is.IPv6,
 		),
 		"name": validation.Validate(
-			m.Name, validation.Required, validation.Length(2, 32),
+			m.Name, validation.Length(2, 32),
 		),
 		"url": validation.Validate(
 			m.Url, is.RequestURL,

--- a/pkg/generators/models/testdata/cases/validation/expected/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_person.go
@@ -15,7 +15,7 @@ import (
 // Person is an object.
 type Person struct {
 	// Age:
-	Age float32 `json:"age,omitempty"`
+	Age float64 `json:"age,omitempty"`
 	// Base64:
 	Base64 string `json:"base64,omitempty"`
 	// Date:
@@ -46,7 +46,7 @@ type Person struct {
 func (m Person) Validate() error {
 	return validation.Errors{
 		"age": validation.Validate(
-			m.Age, validation.Required, validation.Min(float32(18)), validation.Max(float32(120)),
+			m.Age, validation.Required, validation.Min(float64(18)), validation.Max(float64(120)),
 		),
 		"base64": validation.Validate(
 			m.Base64, is.Base64,
@@ -88,12 +88,12 @@ func (m Person) Validate() error {
 }
 
 // GetAge returns the Age property
-func (m Person) GetAge() float32 {
+func (m Person) GetAge() float64 {
 	return m.Age
 }
 
 // SetAge sets the Age property
-func (m Person) SetAge(val float32) {
+func (m Person) SetAge(val float64) {
 	m.Age = val
 }
 

--- a/pkg/generators/models/testdata/cases/validation/expected/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_person.go
@@ -6,30 +6,83 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"time"
+
+	"github.com/go-ozzo/ozzo-validation/v4/is"
 )
 
 // Person is an object.
 type Person struct {
 	// Age:
 	Age float32 `json:"age,omitempty"`
+	// Base64:
+	Base64 string `json:"base64,omitempty"`
+	// Date:
+	Date string `json:"date,omitempty"`
+	// Datetime:
+	Datetime time.Time `json:"datetime,omitempty"`
+	// Email:
+	Email string `json:"email,omitempty"`
 	// Gender:
 	Gender Gender `json:"gender"`
+	// Hostname:
+	Hostname string `json:"hostname,omitempty"`
+	// Ip:
+	Ip string `json:"ip,omitempty"`
+	// Ipv4:
+	Ipv4 string `json:"ipv4,omitempty"`
+	// Ipv6:
+	Ipv6 string `json:"ipv6,omitempty"`
 	// Name:
 	Name string `json:"name"`
+	// Url:
+	Url string `json:"url,omitempty"`
+	// Uuid:
+	Uuid string `json:"uuid,omitempty"`
 }
 
 // Validate implements basic validation for this model
 func (m Person) Validate() error {
 	return validation.Errors{
 		"age": validation.Validate(
-			m.Age, validation.Min(0), validation.Max(120),
+			m.Age, validation.Min(float32(18)), validation.Max(float32(120)),
+		),
+		"base64": validation.Validate(
+			m.Base64,
+		),
+		"date": validation.Validate(
+			m.Date, validation.Date("2006-01-02"),
+		),
+		"datetime": validation.Validate(
+			m.Datetime, validation.Date(time.RFC3339),
+		),
+		"email": validation.Validate(
+			m.Email, is.Email,
 		),
 		"gender": validation.Validate(
 			m.Gender, validation.Required, InKnownGender,
 		),
+		"hostname": validation.Validate(
+			m.Hostname, is.Host,
+		),
+		"ip": validation.Validate(
+			m.Ip, is.IP,
+		),
+		"ipv4": validation.Validate(
+			m.Ipv4, is.IPv4,
+		),
+		"ipv6": validation.Validate(
+			m.Ipv6, is.IPv6,
+		),
 		"name": validation.Validate(
 			m.Name, validation.Required, validation.Length(2, 32),
+		),
+		"url": validation.Validate(
+			m.Url, is.RequestURL,
+		),
+		"uuid": validation.Validate(
+			m.Uuid, is.UUID,
 		),
 	}.Filter()
 }
@@ -44,6 +97,46 @@ func (m Person) SetAge(val float32) {
 	m.Age = val
 }
 
+// GetBase64 returns the Base64 property
+func (m Person) GetBase64() string {
+	return m.Base64
+}
+
+// SetBase64 sets the Base64 property
+func (m Person) SetBase64(val string) {
+	m.Base64 = val
+}
+
+// GetDate returns the Date property
+func (m Person) GetDate() string {
+	return m.Date
+}
+
+// SetDate sets the Date property
+func (m Person) SetDate(val string) {
+	m.Date = val
+}
+
+// GetDatetime returns the Datetime property
+func (m Person) GetDatetime() time.Time {
+	return m.Datetime
+}
+
+// SetDatetime sets the Datetime property
+func (m Person) SetDatetime(val time.Time) {
+	m.Datetime = val
+}
+
+// GetEmail returns the Email property
+func (m Person) GetEmail() string {
+	return m.Email
+}
+
+// SetEmail sets the Email property
+func (m Person) SetEmail(val string) {
+	m.Email = val
+}
+
 // GetGender returns the Gender property
 func (m Person) GetGender() Gender {
 	return m.Gender
@@ -54,6 +147,46 @@ func (m Person) SetGender(val Gender) {
 	m.Gender = val
 }
 
+// GetHostname returns the Hostname property
+func (m Person) GetHostname() string {
+	return m.Hostname
+}
+
+// SetHostname sets the Hostname property
+func (m Person) SetHostname(val string) {
+	m.Hostname = val
+}
+
+// GetIp returns the Ip property
+func (m Person) GetIp() string {
+	return m.Ip
+}
+
+// SetIp sets the Ip property
+func (m Person) SetIp(val string) {
+	m.Ip = val
+}
+
+// GetIpv4 returns the Ipv4 property
+func (m Person) GetIpv4() string {
+	return m.Ipv4
+}
+
+// SetIpv4 sets the Ipv4 property
+func (m Person) SetIpv4(val string) {
+	m.Ipv4 = val
+}
+
+// GetIpv6 returns the Ipv6 property
+func (m Person) GetIpv6() string {
+	return m.Ipv6
+}
+
+// SetIpv6 sets the Ipv6 property
+func (m Person) SetIpv6(val string) {
+	m.Ipv6 = val
+}
+
 // GetName returns the Name property
 func (m Person) GetName() string {
 	return m.Name
@@ -62,4 +195,24 @@ func (m Person) GetName() string {
 // SetName sets the Name property
 func (m Person) SetName(val string) {
 	m.Name = val
+}
+
+// GetUrl returns the Url property
+func (m Person) GetUrl() string {
+	return m.Url
+}
+
+// SetUrl sets the Url property
+func (m Person) SetUrl(val string) {
+	m.Url = val
+}
+
+// GetUuid returns the Uuid property
+func (m Person) GetUuid() string {
+	return m.Uuid
+}
+
+// SetUuid sets the Uuid property
+func (m Person) SetUuid(val string) {
+	m.Uuid = val
 }

--- a/pkg/generators/models/testdata/cases/validation/expected/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_person.go
@@ -14,6 +14,8 @@ import (
 
 // Person is an object.
 type Person struct {
+	// Address:
+	Address Address `json:"address,omitempty"`
 	// Age:
 	Age float64 `json:"age,omitempty"`
 	// Base64:
@@ -24,6 +26,8 @@ type Person struct {
 	Datetime time.Time `json:"datetime,omitempty"`
 	// Email:
 	Email string `json:"email,omitempty"`
+	// FavoriteColors:
+	FavoriteColors []Color `json:"favoriteColors,omitempty"`
 	// Gender:
 	Gender Gender `json:"gender"`
 	// Hostname:
@@ -45,46 +49,56 @@ type Person struct {
 // Validate implements basic validation for this model
 func (m Person) Validate() error {
 	return validation.Errors{
+		"address": validation.Validate(
+			m.Address, validation.Required,
+		),
 		"age": validation.Validate(
-			m.Age, validation.Min(float64(18)), validation.Max(float64(120)),
+			m.Age, validation.Required, validation.Min(float64(18)), validation.Max(float64(120)),
 		),
 		"base64": validation.Validate(
-			m.Base64, is.Base64,
-		),
-		"date": validation.Validate(
-			m.Date, validation.Date("2006-01-02"),
-		),
-		"datetime": validation.Validate(
-			m.Datetime, validation.Date(time.RFC3339),
+			m.Base64, validation.Required, is.Base64,
 		),
 		"email": validation.Validate(
-			m.Email, is.EmailFormat,
+			m.Email, validation.Required, is.EmailFormat,
+		),
+		"favoriteColors": validation.Validate(
+			m.FavoriteColors, validation.Required, validation.Length(1, 0),
 		),
 		"gender": validation.Validate(
 			m.Gender, validation.Required, InKnownGender,
 		),
 		"hostname": validation.Validate(
-			m.Hostname, is.Host,
+			m.Hostname, validation.Required, is.Host,
 		),
 		"ip": validation.Validate(
-			m.Ip, is.IP,
+			m.Ip, validation.Required, is.IP,
 		),
 		"ipv4": validation.Validate(
-			m.Ipv4, is.IPv4,
+			m.Ipv4, validation.Required, is.IPv4,
 		),
 		"ipv6": validation.Validate(
-			m.Ipv6, is.IPv6,
+			m.Ipv6, validation.Required, is.IPv6,
 		),
 		"name": validation.Validate(
 			m.Name, validation.Required, validation.Length(2, 32),
 		),
 		"url": validation.Validate(
-			m.Url, is.RequestURL,
+			m.Url, validation.Required, is.RequestURL,
 		),
 		"uuid": validation.Validate(
-			m.Uuid, is.UUID,
+			m.Uuid, validation.Required, is.UUID,
 		),
 	}.Filter()
+}
+
+// GetAddress returns the Address property
+func (m Person) GetAddress() Address {
+	return m.Address
+}
+
+// SetAddress sets the Address property
+func (m Person) SetAddress(val Address) {
+	m.Address = val
 }
 
 // GetAge returns the Age property
@@ -135,6 +149,16 @@ func (m Person) GetEmail() string {
 // SetEmail sets the Email property
 func (m Person) SetEmail(val string) {
 	m.Email = val
+}
+
+// GetFavoriteColors returns the FavoriteColors property
+func (m Person) GetFavoriteColors() []Color {
+	return m.FavoriteColors
+}
+
+// SetFavoriteColors sets the FavoriteColors property
+func (m Person) SetFavoriteColors(val []Color) {
+	m.FavoriteColors = val
 }
 
 // GetGender returns the Gender property

--- a/pkg/generators/models/testdata/cases/validation/expected/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_person.go
@@ -1,0 +1,65 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
+// Person is an object.
+type Person struct {
+	// Age:
+	Age float32 `json:"age,omitempty"`
+	// Gender:
+	Gender Gender `json:"gender"`
+	// Name:
+	Name string `json:"name"`
+}
+
+// Validate implements basic validation for this model
+func (m Person) Validate() error {
+	return validation.Errors{
+		"age": validation.Validate(
+			m.Age, validation.Min(0), validation.Max(120),
+		),
+		"gender": validation.Validate(
+			m.Gender, validation.Required, InKnownGender,
+		),
+		"name": validation.Validate(
+			m.Name, validation.Required, validation.Length(2, 32),
+		),
+	}.Filter()
+}
+
+// GetAge returns the Age property
+func (m Person) GetAge() float32 {
+	return m.Age
+}
+
+// SetAge sets the Age property
+func (m Person) SetAge(val float32) {
+	m.Age = val
+}
+
+// GetGender returns the Gender property
+func (m Person) GetGender() Gender {
+	return m.Gender
+}
+
+// SetGender sets the Gender property
+func (m Person) SetGender(val Gender) {
+	m.Gender = val
+}
+
+// GetName returns the Name property
+func (m Person) GetName() string {
+	return m.Name
+}
+
+// SetName sets the Name property
+func (m Person) SetName(val string) {
+	m.Name = val
+}

--- a/pkg/generators/models/testdata/cases/validation/expected/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_person.go
@@ -58,7 +58,7 @@ func (m Person) Validate() error {
 			m.Datetime, validation.Date(time.RFC3339),
 		),
 		"email": validation.Validate(
-			m.Email, is.Email,
+			m.Email, is.EmailFormat,
 		),
 		"gender": validation.Validate(
 			m.Gender, InKnownGender,

--- a/pkg/generators/models/testdata/cases/validation/expected/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_person.go
@@ -46,7 +46,7 @@ type Person struct {
 func (m Person) Validate() error {
 	return validation.Errors{
 		"age": validation.Validate(
-			m.Age, validation.Min(float32(18)), validation.Max(float32(120)),
+			m.Age, validation.Required, validation.Min(float32(18)), validation.Max(float32(120)),
 		),
 		"base64": validation.Validate(
 			m.Base64, is.Base64,
@@ -76,7 +76,7 @@ func (m Person) Validate() error {
 			m.Ipv6, is.IPv6,
 		),
 		"name": validation.Validate(
-			m.Name, validation.Length(2, 32),
+			m.Name, validation.Required, validation.Length(2, 32),
 		),
 		"url": validation.Validate(
 			m.Url, is.RequestURL,

--- a/pkg/generators/models/testdata/cases/validation/expected/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_person.go
@@ -46,7 +46,7 @@ type Person struct {
 func (m Person) Validate() error {
 	return validation.Errors{
 		"age": validation.Validate(
-			m.Age, validation.Required, validation.Min(float64(18)), validation.Max(float64(120)),
+			m.Age, validation.Min(float64(18)), validation.Max(float64(120)),
 		),
 		"base64": validation.Validate(
 			m.Base64, is.Base64,
@@ -61,7 +61,7 @@ func (m Person) Validate() error {
 			m.Email, is.EmailFormat,
 		),
 		"gender": validation.Validate(
-			m.Gender, InKnownGender,
+			m.Gender, validation.Required, InKnownGender,
 		),
 		"hostname": validation.Validate(
 			m.Hostname, is.Host,

--- a/pkg/generators/models/testdata/cases/validation/expected/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_person.go
@@ -50,43 +50,43 @@ type Person struct {
 func (m Person) Validate() error {
 	return validation.Errors{
 		"address": validation.Validate(
-			m.Address, validation.Required,
+			m.Address,
 		),
 		"age": validation.Validate(
-			m.Age, validation.Required, validation.Min(float64(18)), validation.Max(float64(120)),
+			m.Age, validation.Min(float64(18)), validation.Max(float64(120)),
 		),
 		"base64": validation.Validate(
-			m.Base64, validation.Required, is.Base64,
+			m.Base64, is.Base64,
 		),
 		"email": validation.Validate(
-			m.Email, validation.Required, is.EmailFormat,
+			m.Email, is.EmailFormat,
 		),
 		"favoriteColors": validation.Validate(
-			m.FavoriteColors, validation.Required, validation.Length(1, 0),
+			m.FavoriteColors, validation.Length(1, 0),
 		),
 		"gender": validation.Validate(
-			m.Gender, validation.Required, InKnownGender,
+			m.Gender, validation.Required,
 		),
 		"hostname": validation.Validate(
-			m.Hostname, validation.Required, is.Host,
+			m.Hostname, is.Host,
 		),
 		"ip": validation.Validate(
-			m.Ip, validation.Required, is.IP,
+			m.Ip, is.IP,
 		),
 		"ipv4": validation.Validate(
-			m.Ipv4, validation.Required, is.IPv4,
+			m.Ipv4, is.IPv4,
 		),
 		"ipv6": validation.Validate(
-			m.Ipv6, validation.Required, is.IPv6,
+			m.Ipv6, is.IPv6,
 		),
 		"name": validation.Validate(
 			m.Name, validation.Required, validation.Length(2, 32),
 		),
 		"url": validation.Validate(
-			m.Url, validation.Required, is.RequestURL,
+			m.Url, is.RequestURL,
 		),
 		"uuid": validation.Validate(
-			m.Uuid, validation.Required, is.UUID,
+			m.Uuid, is.UUID,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/validation/expected/model_person_test.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_person_test.go
@@ -10,11 +10,11 @@ import (
 
 func TestPerson(t *testing.T) {
 	require.NoError(t, validation.Validate(&Person{
-		Age:      120,
+		Age:      18,
 		Gender:   GenderDefault,
-		Name:     "Foobar",
-		Hostname: "localhost",
-		Email:    "foo@localhost",
+		Name:     "Foo",
+		Hostname: "foobar.com",
+		Email:    "foo@localhost.de",
 		Uuid:     uuid.NewV4().String(),
 	}))
 }

--- a/pkg/generators/models/testdata/cases/validation/expected/model_person_test.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_person_test.go
@@ -10,11 +10,20 @@ import (
 
 func TestPerson(t *testing.T) {
 	require.NoError(t, validation.Validate(&Person{
-		Age:      18,
-		Gender:   GenderDefault,
-		Name:     "Foo",
-		Hostname: "foobar.com",
-		Email:    "foo@localhost.de",
-		Uuid:     uuid.NewV4().String(),
+		Age:            18,
+		Gender:         GenderDefault,
+		Name:           "Foo",
+		Hostname:       "foobar.com",
+		Email:          "foo@localhost.de",
+		Uuid:           uuid.NewV4().String(),
+		Base64:         "Zm9vYmFyCg==",
+		FavoriteColors: []Color{ColorRed},
+		Ip:             "127.0.0.1",
+		Ipv4:           "127.0.0.1",
+		Ipv6:           "::1",
+		Url:            "https://www.google.com",
+		Address: Address{
+			Street: "foo",
+		},
 	}))
 }

--- a/pkg/generators/models/testdata/cases/validation/expected/model_person_test.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_person_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestPerson(t *testing.T) {
+	name := "foo"
 	require.NoError(t, validation.Validate(&Person{
 		Age:            18,
 		Gender:         GenderDefault,
@@ -17,13 +18,14 @@ func TestPerson(t *testing.T) {
 		Email:          "foo@localhost.de",
 		Uuid:           uuid.NewV4().String(),
 		Base64:         "Zm9vYmFyCg==",
-		FavoriteColors: []Color{ColorRed},
+		FavoriteColors: []Color{ColorBlue},
 		Ip:             "127.0.0.1",
 		Ipv4:           "127.0.0.1",
 		Ipv6:           "::1",
 		Url:            "https://www.google.com",
 		Address: Address{
 			Street: "foo",
+			Name:   &name,
 		},
 	}))
 }

--- a/pkg/generators/models/testdata/cases/validation/expected/model_person_test.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_person_test.go
@@ -1,0 +1,20 @@
+package generatortest
+
+import (
+	"testing"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPerson(t *testing.T) {
+	require.NoError(t, validation.Validate(&Person{
+		Age:      120,
+		Gender:   GenderDefault,
+		Name:     "Foobar",
+		Hostname: "localhost",
+		Email:    "foo@localhost",
+		Uuid:     uuid.NewV4().String(),
+	}))
+}

--- a/pkg/generators/models/testdata/cases/validation/generated/model_address.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_address.go
@@ -1,0 +1,62 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Address is an object.
+type Address struct {
+	// Name:
+	Name *string `json:"name"`
+	// Number:
+	Number int64 `json:"number"`
+	// Street:
+	Street string `json:"street"`
+}
+
+// Validate implements basic validation for this model
+func (m Address) Validate() error {
+	return validation.Errors{
+		"name": validation.Validate(
+			m.Name, validation.Length(2, 0),
+		),
+		"street": validation.Validate(
+			m.Street, validation.Required, validation.Length(2, 0),
+		),
+	}.Filter()
+}
+
+// GetName returns the Name property
+func (m Address) GetName() *string {
+	return m.Name
+}
+
+// SetName sets the Name property
+func (m Address) SetName(val *string) {
+	m.Name = val
+}
+
+// GetNumber returns the Number property
+func (m Address) GetNumber() int64 {
+	return m.Number
+}
+
+// SetNumber sets the Number property
+func (m Address) SetNumber(val int64) {
+	m.Number = val
+}
+
+// GetStreet returns the Street property
+func (m Address) GetStreet() string {
+	return m.Street
+}
+
+// SetStreet sets the Street property
+func (m Address) SetStreet(val string) {
+	m.Street = val
+}

--- a/pkg/generators/models/testdata/cases/validation/generated/model_color.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_color.go
@@ -1,0 +1,43 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Color is an enum.
+type Color string
+
+var (
+	ColorBlue   Color = "blue"
+	ColorGreen  Color = "green"
+	ColorRed    Color = "red"
+	ColorYellow Color = "yellow"
+
+	// KnownColor is the list of valid Color
+	KnownColor = []Color{
+		ColorBlue,
+		ColorGreen,
+		ColorRed,
+		ColorYellow,
+	}
+	// KnownColorString is the list of valid Color as string
+	KnownColorString = []string{
+		string(ColorBlue),
+		string(ColorGreen),
+		string(ColorRed),
+		string(ColorYellow),
+	}
+
+	// InKnownColor is an ozzo-validator for Color
+	InKnownColor = validation.In(
+		ColorBlue,
+		ColorGreen,
+		ColorRed,
+		ColorYellow,
+	)
+)

--- a/pkg/generators/models/testdata/cases/validation/generated/model_color.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_color.go
@@ -12,6 +12,11 @@ import (
 // Color is an enum.
 type Color string
 
+// Validate implements basic validation for this model
+func (m Color) Validate() error {
+	return InKnownColor.Validate(m)
+}
+
 var (
 	ColorBlue   Color = "blue"
 	ColorGreen  Color = "green"

--- a/pkg/generators/models/testdata/cases/validation/generated/model_gender.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_gender.go
@@ -1,0 +1,39 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
+// Gender is an enum.
+type Gender string
+
+var (
+	GenderDefault Gender = "default"
+	GenderFemale  Gender = "female"
+	GenderMale    Gender = "male"
+
+	// KnownGender is the list of valid Gender
+	KnownGender = []Gender{
+		GenderDefault,
+		GenderFemale,
+		GenderMale,
+	}
+	// KnownGenderString is the list of valid Gender as string
+	KnownGenderString = []string{
+		string(GenderDefault),
+		string(GenderFemale),
+		string(GenderMale),
+	}
+
+	// InKnownGender is an ozzo-validator for Gender
+	InKnownGender = validation.In(
+		GenderDefault,
+		GenderFemale,
+		GenderMale,
+	)
+)

--- a/pkg/generators/models/testdata/cases/validation/generated/model_gender.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_gender.go
@@ -12,6 +12,11 @@ import (
 // Gender is an enum.
 type Gender string
 
+// Validate implements basic validation for this model
+func (m Gender) Validate() error {
+	return InKnownGender.Validate(m)
+}
+
 var (
 	GenderDefault Gender = "default"
 	GenderFemale  Gender = "female"

--- a/pkg/generators/models/testdata/cases/validation/generated/model_gender.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_gender.go
@@ -6,7 +6,7 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Gender is an enum.

--- a/pkg/generators/models/testdata/cases/validation/generated/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_person.go
@@ -7,9 +7,9 @@ package generatortest
 
 import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
-	"time"
-
 	"github.com/go-ozzo/ozzo-validation/v4/is"
+
+	"time"
 )
 
 // Person is an object.
@@ -49,7 +49,7 @@ func (m Person) Validate() error {
 			m.Age, validation.Min(float32(18)), validation.Max(float32(120)),
 		),
 		"base64": validation.Validate(
-			m.Base64,
+			m.Base64, is.Base64,
 		),
 		"date": validation.Validate(
 			m.Date, validation.Date("2006-01-02"),
@@ -61,7 +61,7 @@ func (m Person) Validate() error {
 			m.Email, is.Email,
 		),
 		"gender": validation.Validate(
-			m.Gender, validation.Required, InKnownGender,
+			m.Gender, InKnownGender,
 		),
 		"hostname": validation.Validate(
 			m.Hostname, is.Host,
@@ -76,7 +76,7 @@ func (m Person) Validate() error {
 			m.Ipv6, is.IPv6,
 		),
 		"name": validation.Validate(
-			m.Name, validation.Required, validation.Length(2, 32),
+			m.Name, validation.Length(2, 32),
 		),
 		"url": validation.Validate(
 			m.Url, is.RequestURL,

--- a/pkg/generators/models/testdata/cases/validation/generated/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_person.go
@@ -15,7 +15,7 @@ import (
 // Person is an object.
 type Person struct {
 	// Age:
-	Age float32 `json:"age,omitempty"`
+	Age float64 `json:"age,omitempty"`
 	// Base64:
 	Base64 string `json:"base64,omitempty"`
 	// Date:
@@ -46,7 +46,7 @@ type Person struct {
 func (m Person) Validate() error {
 	return validation.Errors{
 		"age": validation.Validate(
-			m.Age, validation.Required, validation.Min(float32(18)), validation.Max(float32(120)),
+			m.Age, validation.Required, validation.Min(float64(18)), validation.Max(float64(120)),
 		),
 		"base64": validation.Validate(
 			m.Base64, is.Base64,
@@ -88,12 +88,12 @@ func (m Person) Validate() error {
 }
 
 // GetAge returns the Age property
-func (m Person) GetAge() float32 {
+func (m Person) GetAge() float64 {
 	return m.Age
 }
 
 // SetAge sets the Age property
-func (m Person) SetAge(val float32) {
+func (m Person) SetAge(val float64) {
 	m.Age = val
 }
 

--- a/pkg/generators/models/testdata/cases/validation/generated/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_person.go
@@ -6,30 +6,83 @@
 package generatortest
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"time"
+
+	"github.com/go-ozzo/ozzo-validation/v4/is"
 )
 
 // Person is an object.
 type Person struct {
 	// Age:
 	Age float32 `json:"age,omitempty"`
+	// Base64:
+	Base64 string `json:"base64,omitempty"`
+	// Date:
+	Date string `json:"date,omitempty"`
+	// Datetime:
+	Datetime time.Time `json:"datetime,omitempty"`
+	// Email:
+	Email string `json:"email,omitempty"`
 	// Gender:
 	Gender Gender `json:"gender"`
+	// Hostname:
+	Hostname string `json:"hostname,omitempty"`
+	// Ip:
+	Ip string `json:"ip,omitempty"`
+	// Ipv4:
+	Ipv4 string `json:"ipv4,omitempty"`
+	// Ipv6:
+	Ipv6 string `json:"ipv6,omitempty"`
 	// Name:
 	Name string `json:"name"`
+	// Url:
+	Url string `json:"url,omitempty"`
+	// Uuid:
+	Uuid string `json:"uuid,omitempty"`
 }
 
 // Validate implements basic validation for this model
 func (m Person) Validate() error {
 	return validation.Errors{
 		"age": validation.Validate(
-			m.Age, validation.Min(0), validation.Max(120),
+			m.Age, validation.Min(float32(18)), validation.Max(float32(120)),
+		),
+		"base64": validation.Validate(
+			m.Base64,
+		),
+		"date": validation.Validate(
+			m.Date, validation.Date("2006-01-02"),
+		),
+		"datetime": validation.Validate(
+			m.Datetime, validation.Date(time.RFC3339),
+		),
+		"email": validation.Validate(
+			m.Email, is.Email,
 		),
 		"gender": validation.Validate(
 			m.Gender, validation.Required, InKnownGender,
 		),
+		"hostname": validation.Validate(
+			m.Hostname, is.Host,
+		),
+		"ip": validation.Validate(
+			m.Ip, is.IP,
+		),
+		"ipv4": validation.Validate(
+			m.Ipv4, is.IPv4,
+		),
+		"ipv6": validation.Validate(
+			m.Ipv6, is.IPv6,
+		),
 		"name": validation.Validate(
 			m.Name, validation.Required, validation.Length(2, 32),
+		),
+		"url": validation.Validate(
+			m.Url, is.RequestURL,
+		),
+		"uuid": validation.Validate(
+			m.Uuid, is.UUID,
 		),
 	}.Filter()
 }
@@ -44,6 +97,46 @@ func (m Person) SetAge(val float32) {
 	m.Age = val
 }
 
+// GetBase64 returns the Base64 property
+func (m Person) GetBase64() string {
+	return m.Base64
+}
+
+// SetBase64 sets the Base64 property
+func (m Person) SetBase64(val string) {
+	m.Base64 = val
+}
+
+// GetDate returns the Date property
+func (m Person) GetDate() string {
+	return m.Date
+}
+
+// SetDate sets the Date property
+func (m Person) SetDate(val string) {
+	m.Date = val
+}
+
+// GetDatetime returns the Datetime property
+func (m Person) GetDatetime() time.Time {
+	return m.Datetime
+}
+
+// SetDatetime sets the Datetime property
+func (m Person) SetDatetime(val time.Time) {
+	m.Datetime = val
+}
+
+// GetEmail returns the Email property
+func (m Person) GetEmail() string {
+	return m.Email
+}
+
+// SetEmail sets the Email property
+func (m Person) SetEmail(val string) {
+	m.Email = val
+}
+
 // GetGender returns the Gender property
 func (m Person) GetGender() Gender {
 	return m.Gender
@@ -54,6 +147,46 @@ func (m Person) SetGender(val Gender) {
 	m.Gender = val
 }
 
+// GetHostname returns the Hostname property
+func (m Person) GetHostname() string {
+	return m.Hostname
+}
+
+// SetHostname sets the Hostname property
+func (m Person) SetHostname(val string) {
+	m.Hostname = val
+}
+
+// GetIp returns the Ip property
+func (m Person) GetIp() string {
+	return m.Ip
+}
+
+// SetIp sets the Ip property
+func (m Person) SetIp(val string) {
+	m.Ip = val
+}
+
+// GetIpv4 returns the Ipv4 property
+func (m Person) GetIpv4() string {
+	return m.Ipv4
+}
+
+// SetIpv4 sets the Ipv4 property
+func (m Person) SetIpv4(val string) {
+	m.Ipv4 = val
+}
+
+// GetIpv6 returns the Ipv6 property
+func (m Person) GetIpv6() string {
+	return m.Ipv6
+}
+
+// SetIpv6 sets the Ipv6 property
+func (m Person) SetIpv6(val string) {
+	m.Ipv6 = val
+}
+
 // GetName returns the Name property
 func (m Person) GetName() string {
 	return m.Name
@@ -62,4 +195,24 @@ func (m Person) GetName() string {
 // SetName sets the Name property
 func (m Person) SetName(val string) {
 	m.Name = val
+}
+
+// GetUrl returns the Url property
+func (m Person) GetUrl() string {
+	return m.Url
+}
+
+// SetUrl sets the Url property
+func (m Person) SetUrl(val string) {
+	m.Url = val
+}
+
+// GetUuid returns the Uuid property
+func (m Person) GetUuid() string {
+	return m.Uuid
+}
+
+// SetUuid sets the Uuid property
+func (m Person) SetUuid(val string) {
+	m.Uuid = val
 }

--- a/pkg/generators/models/testdata/cases/validation/generated/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_person.go
@@ -14,6 +14,8 @@ import (
 
 // Person is an object.
 type Person struct {
+	// Address:
+	Address Address `json:"address,omitempty"`
 	// Age:
 	Age float64 `json:"age,omitempty"`
 	// Base64:
@@ -24,6 +26,8 @@ type Person struct {
 	Datetime time.Time `json:"datetime,omitempty"`
 	// Email:
 	Email string `json:"email,omitempty"`
+	// FavoriteColors:
+	FavoriteColors []Color `json:"favoriteColors,omitempty"`
 	// Gender:
 	Gender Gender `json:"gender"`
 	// Hostname:
@@ -45,46 +49,56 @@ type Person struct {
 // Validate implements basic validation for this model
 func (m Person) Validate() error {
 	return validation.Errors{
+		"address": validation.Validate(
+			m.Address, validation.Required,
+		),
 		"age": validation.Validate(
-			m.Age, validation.Min(float64(18)), validation.Max(float64(120)),
+			m.Age, validation.Required, validation.Min(float64(18)), validation.Max(float64(120)),
 		),
 		"base64": validation.Validate(
-			m.Base64, is.Base64,
-		),
-		"date": validation.Validate(
-			m.Date, validation.Date("2006-01-02"),
-		),
-		"datetime": validation.Validate(
-			m.Datetime, validation.Date(time.RFC3339),
+			m.Base64, validation.Required, is.Base64,
 		),
 		"email": validation.Validate(
-			m.Email, is.EmailFormat,
+			m.Email, validation.Required, is.EmailFormat,
+		),
+		"favoriteColors": validation.Validate(
+			m.FavoriteColors, validation.Required, validation.Length(1, 0),
 		),
 		"gender": validation.Validate(
 			m.Gender, validation.Required, InKnownGender,
 		),
 		"hostname": validation.Validate(
-			m.Hostname, is.Host,
+			m.Hostname, validation.Required, is.Host,
 		),
 		"ip": validation.Validate(
-			m.Ip, is.IP,
+			m.Ip, validation.Required, is.IP,
 		),
 		"ipv4": validation.Validate(
-			m.Ipv4, is.IPv4,
+			m.Ipv4, validation.Required, is.IPv4,
 		),
 		"ipv6": validation.Validate(
-			m.Ipv6, is.IPv6,
+			m.Ipv6, validation.Required, is.IPv6,
 		),
 		"name": validation.Validate(
 			m.Name, validation.Required, validation.Length(2, 32),
 		),
 		"url": validation.Validate(
-			m.Url, is.RequestURL,
+			m.Url, validation.Required, is.RequestURL,
 		),
 		"uuid": validation.Validate(
-			m.Uuid, is.UUID,
+			m.Uuid, validation.Required, is.UUID,
 		),
 	}.Filter()
+}
+
+// GetAddress returns the Address property
+func (m Person) GetAddress() Address {
+	return m.Address
+}
+
+// SetAddress sets the Address property
+func (m Person) SetAddress(val Address) {
+	m.Address = val
 }
 
 // GetAge returns the Age property
@@ -135,6 +149,16 @@ func (m Person) GetEmail() string {
 // SetEmail sets the Email property
 func (m Person) SetEmail(val string) {
 	m.Email = val
+}
+
+// GetFavoriteColors returns the FavoriteColors property
+func (m Person) GetFavoriteColors() []Color {
+	return m.FavoriteColors
+}
+
+// SetFavoriteColors sets the FavoriteColors property
+func (m Person) SetFavoriteColors(val []Color) {
+	m.FavoriteColors = val
 }
 
 // GetGender returns the Gender property

--- a/pkg/generators/models/testdata/cases/validation/generated/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_person.go
@@ -1,0 +1,65 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
+// Person is an object.
+type Person struct {
+	// Age:
+	Age float32 `json:"age,omitempty"`
+	// Gender:
+	Gender Gender `json:"gender"`
+	// Name:
+	Name string `json:"name"`
+}
+
+// Validate implements basic validation for this model
+func (m Person) Validate() error {
+	return validation.Errors{
+		"age": validation.Validate(
+			m.Age, validation.Min(0), validation.Max(120),
+		),
+		"gender": validation.Validate(
+			m.Gender, validation.Required, InKnownGender,
+		),
+		"name": validation.Validate(
+			m.Name, validation.Required, validation.Length(2, 32),
+		),
+	}.Filter()
+}
+
+// GetAge returns the Age property
+func (m Person) GetAge() float32 {
+	return m.Age
+}
+
+// SetAge sets the Age property
+func (m Person) SetAge(val float32) {
+	m.Age = val
+}
+
+// GetGender returns the Gender property
+func (m Person) GetGender() Gender {
+	return m.Gender
+}
+
+// SetGender sets the Gender property
+func (m Person) SetGender(val Gender) {
+	m.Gender = val
+}
+
+// GetName returns the Name property
+func (m Person) GetName() string {
+	return m.Name
+}
+
+// SetName sets the Name property
+func (m Person) SetName(val string) {
+	m.Name = val
+}

--- a/pkg/generators/models/testdata/cases/validation/generated/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_person.go
@@ -58,7 +58,7 @@ func (m Person) Validate() error {
 			m.Datetime, validation.Date(time.RFC3339),
 		),
 		"email": validation.Validate(
-			m.Email, is.Email,
+			m.Email, is.EmailFormat,
 		),
 		"gender": validation.Validate(
 			m.Gender, InKnownGender,

--- a/pkg/generators/models/testdata/cases/validation/generated/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_person.go
@@ -46,7 +46,7 @@ type Person struct {
 func (m Person) Validate() error {
 	return validation.Errors{
 		"age": validation.Validate(
-			m.Age, validation.Min(float32(18)), validation.Max(float32(120)),
+			m.Age, validation.Required, validation.Min(float32(18)), validation.Max(float32(120)),
 		),
 		"base64": validation.Validate(
 			m.Base64, is.Base64,
@@ -76,7 +76,7 @@ func (m Person) Validate() error {
 			m.Ipv6, is.IPv6,
 		),
 		"name": validation.Validate(
-			m.Name, validation.Length(2, 32),
+			m.Name, validation.Required, validation.Length(2, 32),
 		),
 		"url": validation.Validate(
 			m.Url, is.RequestURL,

--- a/pkg/generators/models/testdata/cases/validation/generated/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_person.go
@@ -46,7 +46,7 @@ type Person struct {
 func (m Person) Validate() error {
 	return validation.Errors{
 		"age": validation.Validate(
-			m.Age, validation.Required, validation.Min(float64(18)), validation.Max(float64(120)),
+			m.Age, validation.Min(float64(18)), validation.Max(float64(120)),
 		),
 		"base64": validation.Validate(
 			m.Base64, is.Base64,
@@ -61,7 +61,7 @@ func (m Person) Validate() error {
 			m.Email, is.EmailFormat,
 		),
 		"gender": validation.Validate(
-			m.Gender, InKnownGender,
+			m.Gender, validation.Required, InKnownGender,
 		),
 		"hostname": validation.Validate(
 			m.Hostname, is.Host,

--- a/pkg/generators/models/testdata/cases/validation/generated/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_person.go
@@ -50,43 +50,43 @@ type Person struct {
 func (m Person) Validate() error {
 	return validation.Errors{
 		"address": validation.Validate(
-			m.Address, validation.Required,
+			m.Address,
 		),
 		"age": validation.Validate(
-			m.Age, validation.Required, validation.Min(float64(18)), validation.Max(float64(120)),
+			m.Age, validation.Min(float64(18)), validation.Max(float64(120)),
 		),
 		"base64": validation.Validate(
-			m.Base64, validation.Required, is.Base64,
+			m.Base64, is.Base64,
 		),
 		"email": validation.Validate(
-			m.Email, validation.Required, is.EmailFormat,
+			m.Email, is.EmailFormat,
 		),
 		"favoriteColors": validation.Validate(
-			m.FavoriteColors, validation.Required, validation.Length(1, 0),
+			m.FavoriteColors, validation.Length(1, 0),
 		),
 		"gender": validation.Validate(
-			m.Gender, validation.Required, InKnownGender,
+			m.Gender, validation.Required,
 		),
 		"hostname": validation.Validate(
-			m.Hostname, validation.Required, is.Host,
+			m.Hostname, is.Host,
 		),
 		"ip": validation.Validate(
-			m.Ip, validation.Required, is.IP,
+			m.Ip, is.IP,
 		),
 		"ipv4": validation.Validate(
-			m.Ipv4, validation.Required, is.IPv4,
+			m.Ipv4, is.IPv4,
 		),
 		"ipv6": validation.Validate(
-			m.Ipv6, validation.Required, is.IPv6,
+			m.Ipv6, is.IPv6,
 		),
 		"name": validation.Validate(
 			m.Name, validation.Required, validation.Length(2, 32),
 		),
 		"url": validation.Validate(
-			m.Url, validation.Required, is.RequestURL,
+			m.Url, is.RequestURL,
 		),
 		"uuid": validation.Validate(
-			m.Uuid, validation.Required, is.UUID,
+			m.Uuid, is.UUID,
 		),
 	}.Filter()
 }


### PR DESCRIPTION
This adds a `Validate() error` method to each of the struct models.

It supports
* minimum and  maximum for numbers
* minLength and maxLength for strings
* checks for valid enum values using the validation rules from the enum generation
* recursive validation, i.e. if we have a subobject which is also from the spec, it also gets validated.
* format "date"
* format "date-time"
* format "bytes"
* format "email"
* format "uuid"
* format "url"
* format "hostname"
* format "ip"
* format "ipv4"
* format "ipv6"

All of the models now implement the `Validatable` interface of ozzo, so this method gets call when calling `validation.Validate(myModelInstance)`

## Ticket
<!-- Paste the url for the jira task/bug or Github issue here -->

## How Has This Been Verified?
All the testcases are updated.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [ ] New code can be debugged via logs.
- [x] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [x] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
