### PR TITLE
default to 32 bit numbers

### DIFF
--- a/pkg/generators/models/go_type_from_ref.go
+++ b/pkg/generators/models/go_type_from_ref.go
@@ -47,7 +47,7 @@ func goTypeFromSpec(schemaRef *openapi3.SchemaRef) string {
 		case "int64":
 			propertyType = "int64"
 		default:
-			propertyType = "int32"
+			propertyType = "int32" // the default is int32 because this is always json-serialized to a proper number in contrast to int64 which will become a string
 		}
 	case "number":
 		switch schemaRef.Value.Format {
@@ -56,7 +56,7 @@ func goTypeFromSpec(schemaRef *openapi3.SchemaRef) string {
 		case "double":
 			propertyType = "float64"
 		default:
-			propertyType = "float32"
+			propertyType = "float32" // the default is float32 because this is always json-serialized to a proper number in contrast to float64 which will become a string
 		}
 	case "":
 		if schemaRef.Ref != "" {

--- a/pkg/generators/models/go_type_from_ref.go
+++ b/pkg/generators/models/go_type_from_ref.go
@@ -47,7 +47,7 @@ func goTypeFromSpec(schemaRef *openapi3.SchemaRef) string {
 		case "int64":
 			propertyType = "int64"
 		default:
-			propertyType = "int64"
+			propertyType = "int32"
 		}
 	case "number":
 		switch schemaRef.Value.Format {
@@ -56,7 +56,7 @@ func goTypeFromSpec(schemaRef *openapi3.SchemaRef) string {
 		case "double":
 			propertyType = "float64"
 		default:
-			propertyType = "float64"
+			propertyType = "float32"
 		}
 	case "":
 		if schemaRef.Ref != "" {

--- a/pkg/generators/models/testdata/cases/validation/expected/model_address.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_address.go
@@ -14,7 +14,7 @@ type Address struct {
 	// Name:
 	Name *string `json:"name"`
 	// Number:
-	Number int64 `json:"number"`
+	Number int32 `json:"number"`
 	// Street:
 	Street string `json:"street"`
 }
@@ -42,12 +42,12 @@ func (m Address) SetName(val *string) {
 }
 
 // GetNumber returns the Number property
-func (m Address) GetNumber() int64 {
+func (m Address) GetNumber() int32 {
 	return m.Number
 }
 
 // SetNumber sets the Number property
-func (m Address) SetNumber(val int64) {
+func (m Address) SetNumber(val int32) {
 	m.Number = val
 }
 

--- a/pkg/generators/models/testdata/cases/validation/expected/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_person.go
@@ -17,7 +17,7 @@ type Person struct {
 	// Address:
 	Address Address `json:"address,omitempty"`
 	// Age:
-	Age float64 `json:"age,omitempty"`
+	Age float32 `json:"age,omitempty"`
 	// Base64:
 	Base64 string `json:"base64,omitempty"`
 	// Date:
@@ -53,7 +53,7 @@ func (m Person) Validate() error {
 			m.Address,
 		),
 		"age": validation.Validate(
-			m.Age, validation.Min(float64(18)), validation.Max(float64(120)),
+			m.Age, validation.Min(float32(18)), validation.Max(float32(120)),
 		),
 		"base64": validation.Validate(
 			m.Base64, is.Base64,
@@ -102,12 +102,12 @@ func (m Person) SetAddress(val Address) {
 }
 
 // GetAge returns the Age property
-func (m Person) GetAge() float64 {
+func (m Person) GetAge() float32 {
 	return m.Age
 }
 
 // SetAge sets the Age property
-func (m Person) SetAge(val float64) {
+func (m Person) SetAge(val float32) {
 	m.Age = val
 }
 

--- a/pkg/generators/models/testdata/cases/validation/generated/model_address.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_address.go
@@ -14,7 +14,7 @@ type Address struct {
 	// Name:
 	Name *string `json:"name"`
 	// Number:
-	Number int64 `json:"number"`
+	Number int32 `json:"number"`
 	// Street:
 	Street string `json:"street"`
 }
@@ -42,12 +42,12 @@ func (m Address) SetName(val *string) {
 }
 
 // GetNumber returns the Number property
-func (m Address) GetNumber() int64 {
+func (m Address) GetNumber() int32 {
 	return m.Number
 }
 
 // SetNumber sets the Number property
-func (m Address) SetNumber(val int64) {
+func (m Address) SetNumber(val int32) {
 	m.Number = val
 }
 

--- a/pkg/generators/models/testdata/cases/validation/generated/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_person.go
@@ -17,7 +17,7 @@ type Person struct {
 	// Address:
 	Address Address `json:"address,omitempty"`
 	// Age:
-	Age float64 `json:"age,omitempty"`
+	Age float32 `json:"age,omitempty"`
 	// Base64:
 	Base64 string `json:"base64,omitempty"`
 	// Date:
@@ -53,7 +53,7 @@ func (m Person) Validate() error {
 			m.Address,
 		),
 		"age": validation.Validate(
-			m.Age, validation.Min(float64(18)), validation.Max(float64(120)),
+			m.Age, validation.Min(float32(18)), validation.Max(float32(120)),
 		),
 		"base64": validation.Validate(
 			m.Base64, is.Base64,
@@ -102,12 +102,12 @@ func (m Person) SetAddress(val Address) {
 }
 
 // GetAge returns the Age property
-func (m Person) GetAge() float64 {
+func (m Person) GetAge() float32 {
 	return m.Age
 }
 
 // SetAge sets the Age property
-func (m Person) SetAge(val float64) {
+func (m Person) SetAge(val float32) {
 	m.Age = val
 }
 


### PR DESCRIPTION
default to 32 bit numbers to avoid an incompatible change in the typesystem (int32 and int64 behave differently when serializing via json)

## Ticket
<!-- Paste the url for the jira task/bug or Github issue here -->

## How Has This Been Verified?
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The change works as expected.
- [ ] New code can be debugged via logs.
- [ ] I have added tests to cover my changes.
- [ ] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
