### PR TITLE
add support for toplevel models that are map[string]Something

### DIFF
--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -85,6 +85,12 @@ func NewModelFromRef(ref *openapi3.SchemaRef) (model *Model, err error) {
 		len(ref.Value.OneOf) > 0:
 		model.Kind = Struct
 		model.Properties, model.Imports, err = structPropsFromRef(ref)
+		if len(model.Properties) == 0 {
+			model.GoType = "map[string]interface{}"
+			if ref.Value.AdditionalProperties != nil {
+				model.GoType = "map[string]" + goTypeFromSpec(ref.Value.AdditionalProperties)
+			}
+		}
 	default:
 		return nil, errors.New("type not handled")
 	}

--- a/pkg/generators/models/models_test.go
+++ b/pkg/generators/models/models_test.go
@@ -76,6 +76,10 @@ func TestModels(t *testing.T) {
 			directory: "testdata/cases/object_with_additional_properties",
 		},
 		{
+			name:      "an untyped toplevel object may have additional properties of a specific type",
+			directory: "testdata/cases/toplevel_object_with_additional_properties",
+		},
+		{
 			name:      "handles string enums",
 			directory: "testdata/cases/enum",
 		},

--- a/pkg/generators/models/templates.go
+++ b/pkg/generators/models/templates.go
@@ -49,7 +49,7 @@ import (
 
 {{ (printf "%s is an object. %s" .Name .Description) | commentBlock }}
 {{- if not .Properties }}
-type {{.Name}} map[string]interface{}
+type {{.Name}} {{ .GoType }}
 {{- else }}
 type {{.Name}} struct {
 {{- range .Properties}}

--- a/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/api.yaml
+++ b/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/api.yaml
@@ -9,3 +9,13 @@ components:
       type: object
       additionalProperties:
         type: string
+    Bar:
+      type: object
+      additionalProperties:
+        $ref: "#/components/schemas/Foo"
+    Baz:
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          $ref: "#/components/schemas/Bar"

--- a/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/api.yaml
+++ b/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/api.yaml
@@ -19,3 +19,10 @@ components:
         type: array
         items:
           $ref: "#/components/schemas/Bar"
+    Quak:
+      type: object
+      additionalProperties:
+        oneof:
+          - $ref: "#/components/schemas/Foo"
+          - $ref: "#/components/schemas/Bar"
+      

--- a/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/api.yaml
+++ b/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/api.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.0
+info:
+  version: 0.1.0
+  title: Test
+
+components:
+  schemas:
+    Foo:
+      type: object
+      additionalProperties:
+        type: string

--- a/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/expected/model_bar.go
+++ b/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/expected/model_bar.go
@@ -1,0 +1,18 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Bar is an object.
+type Bar map[string]Foo
+
+// Validate implements basic validation for this model
+func (m Bar) Validate() error {
+	return validation.Errors{}.Filter()
+}

--- a/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/expected/model_baz.go
+++ b/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/expected/model_baz.go
@@ -1,0 +1,18 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Baz is an object.
+type Baz map[string][]Bar
+
+// Validate implements basic validation for this model
+func (m Baz) Validate() error {
+	return validation.Errors{}.Filter()
+}

--- a/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/expected/model_foo.go
@@ -1,0 +1,18 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Foo is an object.
+type Foo map[string]string
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{}.Filter()
+}

--- a/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/expected/model_quak.go
+++ b/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/expected/model_quak.go
@@ -1,0 +1,18 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Quak is an object.
+type Quak map[string]interface{}
+
+// Validate implements basic validation for this model
+func (m Quak) Validate() error {
+	return validation.Errors{}.Filter()
+}

--- a/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/generated/model_bar.go
+++ b/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/generated/model_bar.go
@@ -1,0 +1,18 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Bar is an object.
+type Bar map[string]Foo
+
+// Validate implements basic validation for this model
+func (m Bar) Validate() error {
+	return validation.Errors{}.Filter()
+}

--- a/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/generated/model_baz.go
+++ b/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/generated/model_baz.go
@@ -1,0 +1,18 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Baz is an object.
+type Baz map[string][]Bar
+
+// Validate implements basic validation for this model
+func (m Baz) Validate() error {
+	return validation.Errors{}.Filter()
+}

--- a/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/generated/model_foo.go
@@ -1,0 +1,18 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Foo is an object.
+type Foo map[string]string
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{}.Filter()
+}

--- a/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/generated/model_quak.go
+++ b/pkg/generators/models/testdata/cases/toplevel_object_with_additional_properties/generated/model_quak.go
@@ -1,0 +1,18 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Quak is an object.
+type Quak map[string]interface{}
+
+// Validate implements basic validation for this model
+func (m Quak) Validate() error {
+	return validation.Errors{}.Filter()
+}


### PR DESCRIPTION
Before this change all objects with no props on the toplevel got rendered to map[string]interface{}.

I basically want this to render this api spec:
```
LinkOverviewGroups:
  type: object
  description: mapping from linkType -> list of links
  additionalProperties:
    type: array
    items:
      $ref: "#/components/schemas/LinkResponse"
```

<!-- Summary of changes above here -->

## Ticket
<!-- Paste the url for the jira task/bug or Github issue here -->

## How Has This Been Verified?
I added a testcase for this.
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [ ] New code can be debugged via logs.
- [x] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
