### PR TITLE
add support for generating query parameter models.

### DIFF
--- a/pkg/generators/models/generate.go
+++ b/pkg/generators/models/generate.go
@@ -44,25 +44,180 @@ func Generate(specFile io.Reader, dst string, opts Options) error {
 	}
 
 	for _, path := range swagger.Paths {
-		if path.Post != nil {
-			operationID := path.Post.OperationID
-			schema := schemaFromOperation(path.Post)
+		if path.Connect != nil {
+			operationID := path.Connect.OperationID
+			schema := requestBodySchemaFromOperation(path.Connect)
 			if operationID != "" && schema != nil && schema.Ref == "" {
 				swagger.Components.Schemas[operationID+"Body"] = schema
+			}
+			path.Connect.Parameters = append(path.Parameters, path.Connect.Parameters...)
+			if len(path.Connect.Parameters) > 0 {
+				model, err := NewModelFromParameters(path.Connect.Parameters)
+				if err != nil {
+					continue
+				}
+				model.Name = tpl.ToPascalCase(path.Connect.OperationID + "QueryParameters")
+				model.PackageName = opts.PackageName
+				model.SpecTitle = swagger.Info.Title
+				model.SpecVersion = swagger.Info.Version
+				err = writeModelToFile(model, dst)
+				if err != nil {
+					continue
+				}
+			}
+		}
+		if path.Head != nil {
+			operationID := path.Connect.OperationID
+			schema := requestBodySchemaFromOperation(path.Head)
+			if operationID != "" && schema != nil && schema.Ref == "" {
+				swagger.Components.Schemas[operationID+"Body"] = schema
+			}
+			path.Head.Parameters = append(path.Parameters, path.Head.Parameters...)
+			if len(path.Head.Parameters) > 0 {
+				model, err := NewModelFromParameters(path.Head.Parameters)
+				if err != nil {
+					continue
+				}
+				model.Name = tpl.ToPascalCase(path.Head.OperationID + "QueryParameters")
+				model.PackageName = opts.PackageName
+				model.SpecTitle = swagger.Info.Title
+				model.SpecVersion = swagger.Info.Version
+				err = writeModelToFile(model, dst)
+				if err != nil {
+					continue
+				}
+			}
+		}
+		if path.Get != nil {
+			operationID := path.Get.OperationID
+			schema := requestBodySchemaFromOperation(path.Get)
+			if operationID != "" && schema != nil && schema.Ref == "" {
+				swagger.Components.Schemas[operationID+"Body"] = schema
+			}
+			path.Get.Parameters = append(path.Parameters, path.Get.Parameters...)
+			if len(path.Get.Parameters) > 0 {
+				model, err := NewModelFromParameters(path.Get.Parameters)
+				if err != nil {
+					continue
+				}
+				model.Name = tpl.ToPascalCase(path.Get.OperationID + "QueryParameters")
+				model.PackageName = opts.PackageName
+				model.SpecTitle = swagger.Info.Title
+				model.SpecVersion = swagger.Info.Version
+				err = writeModelToFile(model, dst)
+				if err != nil {
+					continue
+				}
+			}
+		}
+		if path.Options != nil {
+			operationID := path.Options.OperationID
+			schema := requestBodySchemaFromOperation(path.Options)
+			if operationID != "" && schema != nil && schema.Ref == "" {
+				swagger.Components.Schemas[operationID+"Body"] = schema
+			}
+			path.Options.Parameters = append(path.Parameters, path.Options.Parameters...)
+			if len(path.Options.Parameters) > 0 {
+				model, err := NewModelFromParameters(path.Options.Parameters)
+				if err != nil {
+					continue
+				}
+				model.Name = tpl.ToPascalCase(path.Options.OperationID + "QueryParameters")
+				model.PackageName = opts.PackageName
+				model.SpecTitle = swagger.Info.Title
+				model.SpecVersion = swagger.Info.Version
+				err = writeModelToFile(model, dst)
+				if err != nil {
+					continue
+				}
+			}
+		}
+		if path.Delete != nil {
+			operationID := path.Delete.OperationID
+			schema := requestBodySchemaFromOperation(path.Delete)
+			if operationID != "" && schema != nil && schema.Ref == "" {
+				swagger.Components.Schemas[operationID+"Body"] = schema
+			}
+			path.Delete.Parameters = append(path.Parameters, path.Delete.Parameters...)
+			if len(path.Delete.Parameters) > 0 {
+				model, err := NewModelFromParameters(path.Delete.Parameters)
+				if err != nil {
+					continue
+				}
+				model.Name = tpl.ToPascalCase(path.Delete.OperationID + "QueryParameters")
+				model.PackageName = opts.PackageName
+				model.SpecTitle = swagger.Info.Title
+				model.SpecVersion = swagger.Info.Version
+				err = writeModelToFile(model, dst)
+				if err != nil {
+					continue
+				}
+			}
+		}
+		if path.Post != nil {
+			operationID := path.Post.OperationID
+			schema := requestBodySchemaFromOperation(path.Post)
+			if operationID != "" && schema != nil && schema.Ref == "" {
+				swagger.Components.Schemas[operationID+"Body"] = schema
+			}
+			path.Post.Parameters = append(path.Parameters, path.Post.Parameters...)
+			if len(path.Post.Parameters) > 0 {
+				model, err := NewModelFromParameters(path.Post.Parameters)
+				if err != nil {
+					continue
+				}
+				model.Name = tpl.ToPascalCase(path.Post.OperationID + "QueryParameters")
+				model.PackageName = opts.PackageName
+				model.SpecTitle = swagger.Info.Title
+				model.SpecVersion = swagger.Info.Version
+				err = writeModelToFile(model, dst)
+				if err != nil {
+					continue
+				}
 			}
 		}
 		if path.Put != nil {
 			operationID := path.Put.OperationID
-			schema := schemaFromOperation(path.Put)
+			schema := requestBodySchemaFromOperation(path.Put)
 			if operationID != "" && schema != nil && schema.Ref == "" {
 				swagger.Components.Schemas[operationID+"Body"] = schema
+			}
+			path.Put.Parameters = append(path.Parameters, path.Put.Parameters...)
+			if len(path.Put.Parameters) > 0 {
+				model, err := NewModelFromParameters(path.Put.Parameters)
+				if err != nil {
+					continue
+				}
+				model.Name = tpl.ToPascalCase(path.Put.OperationID + "QueryParameters")
+				model.PackageName = opts.PackageName
+				model.SpecTitle = swagger.Info.Title
+				model.SpecVersion = swagger.Info.Version
+				err = writeModelToFile(model, dst)
+				if err != nil {
+					continue
+				}
 			}
 		}
 		if path.Patch != nil {
 			operationID := path.Patch.OperationID
-			schema := schemaFromOperation(path.Patch)
+			schema := requestBodySchemaFromOperation(path.Patch)
 			if operationID != "" && schema != nil && schema.Ref == "" {
 				swagger.Components.Schemas[operationID+"Body"] = schema
+			}
+			path.Patch.Parameters = append(path.Parameters, path.Patch.Parameters...)
+			if len(path.Patch.Parameters) > 0 {
+				model, err := NewModelFromParameters(path.Patch.Parameters)
+				if err != nil {
+					continue
+				}
+				model.Name = tpl.ToPascalCase(path.Patch.OperationID + "QueryParameters")
+				model.PackageName = opts.PackageName
+				model.SpecTitle = swagger.Info.Title
+				model.SpecVersion = swagger.Info.Version
+				err = writeModelToFile(model, dst)
+				if err != nil {
+					continue
+				}
 			}
 		}
 	}
@@ -83,27 +238,9 @@ func Generate(specFile io.Reader, dst string, opts Options) error {
 		model.SpecTitle = swagger.Info.Title
 		model.SpecVersion = swagger.Info.Version
 
-		modelName := strings.ToLower(strings.ReplaceAll(fmt.Sprintf("model_%s.go", tpl.ToSnakeCase(model.Name)), " ", "_"))
-
-		buf := &bytes.Buffer{}
-		err = model.Render(context.TODO(), buf)
+		err = writeModelToFile(model, dst)
 		if err != nil {
-			log.Error().Str("name", name).Err(err).Msg("failed to render model")
-			continue
-		}
-
-		content, err := format.Source(buf.Bytes())
-		if err != nil {
-			log.Error().Str("name", name).Err(err).Msg("failed to format source code")
-			fmt.Println(string(buf.Bytes()))
-			continue
-		}
-
-		target := filepath.Join(dst, modelName)
-		err = ioutil.WriteFile(target, content, 0644)
-		if err != nil {
-			log.Error().Str("name", name).Str("path", target).Err(err).Msg("failed to write model to file")
-			continue
+			return err
 		}
 	}
 
@@ -111,12 +248,38 @@ func Generate(specFile io.Reader, dst string, opts Options) error {
 
 }
 
-func schemaFromOperation(op *openapi3.Operation) *openapi3.SchemaRef {
+func requestBodySchemaFromOperation(op *openapi3.Operation) *openapi3.SchemaRef {
 	if op.RequestBody != nil && op.RequestBody.Value != nil && op.RequestBody.Value.Content != nil {
 		content, ok := op.RequestBody.Value.Content["application/json"]
 		if ok {
 			return content.Schema
 		}
+	}
+	return nil
+}
+
+func writeModelToFile(model *Model, dst string) error {
+	modelName := strings.ToLower(strings.ReplaceAll(fmt.Sprintf("model_%s.go", tpl.ToSnakeCase(model.Name)), " ", "_"))
+
+	buf := &bytes.Buffer{}
+	err := model.Render(context.TODO(), buf)
+	if err != nil {
+		log.Error().Str("name", model.Name).Err(err).Msg("failed to render model")
+		return err
+	}
+
+	content, err := format.Source(buf.Bytes())
+	if err != nil {
+		log.Error().Str("name", model.Name).Err(err).Msg("failed to format source code")
+		fmt.Println(string(buf.Bytes()))
+		return err
+	}
+
+	target := filepath.Join(dst, modelName)
+	err = ioutil.WriteFile(target, content, 0644)
+	if err != nil {
+		log.Error().Str("name", model.Name).Str("path", target).Err(err).Msg("failed to write model to file")
+		return err
 	}
 	return nil
 }

--- a/pkg/generators/models/models_test.go
+++ b/pkg/generators/models/models_test.go
@@ -96,6 +96,10 @@ func TestModels(t *testing.T) {
 			name:      "enum with name collision",
 			directory: "testdata/cases/enum_with_name_collision",
 		},
+		{
+			name:      "model from path parameters",
+			directory: "testdata/cases/parameter_model",
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/generators/models/testdata/cases/parameter_model/api.yaml
+++ b/pkg/generators/models/testdata/cases/parameter_model/api.yaml
@@ -20,6 +20,12 @@ paths:
             type: integer
             minimum: 0
             maximum: 10
+        - name: param3
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
       responses:
         "200":
           description: foobar

--- a/pkg/generators/models/testdata/cases/parameter_model/api.yaml
+++ b/pkg/generators/models/testdata/cases/parameter_model/api.yaml
@@ -4,10 +4,16 @@ info:
   title: Test
 
 paths:
-  "/foo":
+  "/foo/{id}":
     parameters:
       - name: param1
         in: query
+        schema:
+          type: string
+          format: uuid
+      - name: id
+        required: true
+        in: path
         schema:
           type: string
           format: uuid

--- a/pkg/generators/models/testdata/cases/parameter_model/api.yaml
+++ b/pkg/generators/models/testdata/cases/parameter_model/api.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  version: 0.1.0
+  title: Test
+
+paths:
+  "/foo":
+    parameters:
+      - name: param1
+        in: query
+        schema:
+          type: string
+          format: uuid
+    get:
+      operationId: getFoo
+      parameters:
+        - name: param2
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 10
+      responses:
+        "200":
+          description: foobar
+
+components:
+  schemas: {}

--- a/pkg/generators/models/testdata/cases/parameter_model/expected/model_get_foo_query_parameters.go
+++ b/pkg/generators/models/testdata/cases/parameter_model/expected/model_get_foo_query_parameters.go
@@ -16,6 +16,8 @@ type GetFooQueryParameters struct {
 	Param1 string `json:"param1,omitempty"`
 	// Param2:
 	Param2 int32 `json:"param2,omitempty"`
+	// Param3:
+	Param3 []string `json:"param3,omitempty"`
 }
 
 // Validate implements basic validation for this model
@@ -26,6 +28,9 @@ func (m GetFooQueryParameters) Validate() error {
 		),
 		"param2": validation.Validate(
 			m.Param2, validation.Min(int32(0)), validation.Max(int32(10)),
+		),
+		"param3": validation.Validate(
+			m.Param3,
 		),
 	}.Filter()
 }
@@ -48,4 +53,14 @@ func (m GetFooQueryParameters) GetParam2() int32 {
 // SetParam2 sets the Param2 property
 func (m GetFooQueryParameters) SetParam2(val int32) {
 	m.Param2 = val
+}
+
+// GetParam3 returns the Param3 property
+func (m GetFooQueryParameters) GetParam3() []string {
+	return m.Param3
+}
+
+// SetParam3 sets the Param3 property
+func (m GetFooQueryParameters) SetParam3(val []string) {
+	m.Param3 = val
 }

--- a/pkg/generators/models/testdata/cases/parameter_model/expected/model_get_foo_query_parameters.go
+++ b/pkg/generators/models/testdata/cases/parameter_model/expected/model_get_foo_query_parameters.go
@@ -1,0 +1,51 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/go-ozzo/ozzo-validation/v4/is"
+)
+
+// GetFooQueryParameters is an object.
+type GetFooQueryParameters struct {
+	// Param1:
+	Param1 string `json:"param1,omitempty"`
+	// Param2:
+	Param2 int32 `json:"param2,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m GetFooQueryParameters) Validate() error {
+	return validation.Errors{
+		"param1": validation.Validate(
+			m.Param1, is.UUID,
+		),
+		"param2": validation.Validate(
+			m.Param2, validation.Min(int32(0)), validation.Max(int32(10)),
+		),
+	}.Filter()
+}
+
+// GetParam1 returns the Param1 property
+func (m GetFooQueryParameters) GetParam1() string {
+	return m.Param1
+}
+
+// SetParam1 sets the Param1 property
+func (m GetFooQueryParameters) SetParam1(val string) {
+	m.Param1 = val
+}
+
+// GetParam2 returns the Param2 property
+func (m GetFooQueryParameters) GetParam2() int32 {
+	return m.Param2
+}
+
+// SetParam2 sets the Param2 property
+func (m GetFooQueryParameters) SetParam2(val int32) {
+	m.Param2 = val
+}

--- a/pkg/generators/models/testdata/cases/parameter_model/expected/model_get_foo_query_parameters.go
+++ b/pkg/generators/models/testdata/cases/parameter_model/expected/model_get_foo_query_parameters.go
@@ -14,6 +14,8 @@ import (
 type GetFooQueryParameters struct {
 	// Param1:
 	Param1 string `json:"param1,omitempty"`
+	// Id:
+	Id string `json:"id"`
 	// Param2:
 	Param2 int32 `json:"param2,omitempty"`
 	// Param3:
@@ -25,6 +27,9 @@ func (m GetFooQueryParameters) Validate() error {
 	return validation.Errors{
 		"param1": validation.Validate(
 			m.Param1, is.UUID,
+		),
+		"id": validation.Validate(
+			m.Id, validation.Required, is.UUID,
 		),
 		"param2": validation.Validate(
 			m.Param2, validation.Min(int32(0)), validation.Max(int32(10)),
@@ -43,6 +48,16 @@ func (m GetFooQueryParameters) GetParam1() string {
 // SetParam1 sets the Param1 property
 func (m GetFooQueryParameters) SetParam1(val string) {
 	m.Param1 = val
+}
+
+// GetId returns the Id property
+func (m GetFooQueryParameters) GetId() string {
+	return m.Id
+}
+
+// SetId sets the Id property
+func (m GetFooQueryParameters) SetId(val string) {
+	m.Id = val
 }
 
 // GetParam2 returns the Param2 property

--- a/pkg/generators/models/testdata/cases/parameter_model/generated/model_get_foo_query_parameters.go
+++ b/pkg/generators/models/testdata/cases/parameter_model/generated/model_get_foo_query_parameters.go
@@ -16,6 +16,8 @@ type GetFooQueryParameters struct {
 	Param1 string `json:"param1,omitempty"`
 	// Param2:
 	Param2 int32 `json:"param2,omitempty"`
+	// Param3:
+	Param3 []string `json:"param3,omitempty"`
 }
 
 // Validate implements basic validation for this model
@@ -26,6 +28,9 @@ func (m GetFooQueryParameters) Validate() error {
 		),
 		"param2": validation.Validate(
 			m.Param2, validation.Min(int32(0)), validation.Max(int32(10)),
+		),
+		"param3": validation.Validate(
+			m.Param3,
 		),
 	}.Filter()
 }
@@ -48,4 +53,14 @@ func (m GetFooQueryParameters) GetParam2() int32 {
 // SetParam2 sets the Param2 property
 func (m GetFooQueryParameters) SetParam2(val int32) {
 	m.Param2 = val
+}
+
+// GetParam3 returns the Param3 property
+func (m GetFooQueryParameters) GetParam3() []string {
+	return m.Param3
+}
+
+// SetParam3 sets the Param3 property
+func (m GetFooQueryParameters) SetParam3(val []string) {
+	m.Param3 = val
 }

--- a/pkg/generators/models/testdata/cases/parameter_model/generated/model_get_foo_query_parameters.go
+++ b/pkg/generators/models/testdata/cases/parameter_model/generated/model_get_foo_query_parameters.go
@@ -1,0 +1,51 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/go-ozzo/ozzo-validation/v4/is"
+)
+
+// GetFooQueryParameters is an object.
+type GetFooQueryParameters struct {
+	// Param1:
+	Param1 string `json:"param1,omitempty"`
+	// Param2:
+	Param2 int32 `json:"param2,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m GetFooQueryParameters) Validate() error {
+	return validation.Errors{
+		"param1": validation.Validate(
+			m.Param1, is.UUID,
+		),
+		"param2": validation.Validate(
+			m.Param2, validation.Min(int32(0)), validation.Max(int32(10)),
+		),
+	}.Filter()
+}
+
+// GetParam1 returns the Param1 property
+func (m GetFooQueryParameters) GetParam1() string {
+	return m.Param1
+}
+
+// SetParam1 sets the Param1 property
+func (m GetFooQueryParameters) SetParam1(val string) {
+	m.Param1 = val
+}
+
+// GetParam2 returns the Param2 property
+func (m GetFooQueryParameters) GetParam2() int32 {
+	return m.Param2
+}
+
+// SetParam2 sets the Param2 property
+func (m GetFooQueryParameters) SetParam2(val int32) {
+	m.Param2 = val
+}

--- a/pkg/generators/models/testdata/cases/parameter_model/generated/model_get_foo_query_parameters.go
+++ b/pkg/generators/models/testdata/cases/parameter_model/generated/model_get_foo_query_parameters.go
@@ -14,6 +14,8 @@ import (
 type GetFooQueryParameters struct {
 	// Param1:
 	Param1 string `json:"param1,omitempty"`
+	// Id:
+	Id string `json:"id"`
 	// Param2:
 	Param2 int32 `json:"param2,omitempty"`
 	// Param3:
@@ -25,6 +27,9 @@ func (m GetFooQueryParameters) Validate() error {
 	return validation.Errors{
 		"param1": validation.Validate(
 			m.Param1, is.UUID,
+		),
+		"id": validation.Validate(
+			m.Id, validation.Required, is.UUID,
 		),
 		"param2": validation.Validate(
 			m.Param2, validation.Min(int32(0)), validation.Max(int32(10)),
@@ -43,6 +48,16 @@ func (m GetFooQueryParameters) GetParam1() string {
 // SetParam1 sets the Param1 property
 func (m GetFooQueryParameters) SetParam1(val string) {
 	m.Param1 = val
+}
+
+// GetId returns the Id property
+func (m GetFooQueryParameters) GetId() string {
+	return m.Id
+}
+
+// SetId sets the Id property
+func (m GetFooQueryParameters) SetId(val string) {
+	m.Id = val
 }
 
 // GetParam2 returns the Param2 property


### PR DESCRIPTION
add support for generating query parameter models.

This will generate a `${OP_ID}QueryParameters` struct for each operation in the spec.

## Ticket
<!-- Paste the url for the jira task/bug or Github issue here -->

## How Has This Been Verified?
I added a non trivial test + I ran it on hub

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [ ] New code can be debugged via logs.
- [x] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [?] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
