### PR TITLE
Add support for value type schemas

### DIFF
--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -28,6 +28,8 @@ const (
 	Struct ModelKind = "struct"
 	// Enum is a Go enum definition
 	Enum ModelKind = "enum"
+	// Value is a value type
+	Value ModelKind = "value"
 )
 
 // Model is a template model for rendering Go code for a given API schema
@@ -122,7 +124,8 @@ func NewModelFromRef(ref *openapi3.SchemaRef) (model *Model, err error) {
 			}
 		}
 	default:
-		return nil, errors.New("cannot detect the model type")
+		model.Kind = Value
+		model.GoType = goTypeFromSpec(ref)
 	}
 	if err != nil {
 		return nil, err
@@ -174,6 +177,8 @@ func (m *Model) Render(ctx context.Context, writer io.Writer) error {
 		tpl = modelTemplate
 	case Enum:
 		tpl = enumTemplate
+	case Value:
+		tpl = valueTemplate
 	}
 
 	err := tpl.Execute(writer, m)

--- a/pkg/generators/models/templates.go
+++ b/pkg/generators/models/templates.go
@@ -19,6 +19,12 @@ var (
 			Parse(enumTemplateSource),
 	)
 
+	valueTemplate = template.Must(
+		template.New("value").
+			Funcs(fmap).
+			Parse(valueTemplateSource),
+	)
+
 	fmap = template.FuncMap{
 		"firstLower":   tpl.FirstLower,
 		"firstUpper":   tpl.FirstUpper,
@@ -142,5 +148,17 @@ var (
 		{{- end}}
 	)
 )
+`
+
+	valueTemplateSource = `
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: {{.SpecTitle}}
+//     Version: {{.SpecVersion}}
+package {{ .PackageName }}
+
+{{ (printf "%s is a value type. %s" .Name .Description) | commentBlock }}
+type {{.Name}} {{.GoType}}
 `
 )

--- a/pkg/generators/models/testdata/cases/embedded_type/api.yaml
+++ b/pkg/generators/models/testdata/cases/embedded_type/api.yaml
@@ -8,10 +8,21 @@ components:
     Top:
       type: object
       properties:
-        bar:
-          $ref: "#/components/schemas/Sub"
-    Sub:
+        obj:
+          $ref: "#/components/schemas/Sub1"
+        arr:
+          $ref: "#/components/schemas/Sub2"
+        boo:
+          $ref: "#/components/schemas/Sub3"
+    Sub1:
       type: object
       properties:
         foo:
           type: string
+    Sub2:
+      type: array
+      items:
+        $ref: "#/components/schemas/Sub1"
+    Sub3:
+      type: bool
+      description: Type alias for a value type

--- a/pkg/generators/models/testdata/cases/embedded_type/expected/model_sub1.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/expected/model_sub1.go
@@ -1,0 +1,31 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Sub1 is an object.
+type Sub1 struct {
+	// Foo:
+	Foo string `json:"foo,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Sub1) Validate() error {
+	return validation.Errors{}.Filter()
+}
+
+// GetFoo returns the Foo property
+func (m Sub1) GetFoo() string {
+	return m.Foo
+}
+
+// SetFoo sets the Foo property
+func (m Sub1) SetFoo(val string) {
+	m.Foo = val
+}

--- a/pkg/generators/models/testdata/cases/embedded_type/expected/model_sub3.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/expected/model_sub3.go
@@ -1,0 +1,9 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+// Sub3 is a value type. Type alias for a value type
+type Sub3 bool

--- a/pkg/generators/models/testdata/cases/embedded_type/expected/model_top.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/expected/model_top.go
@@ -11,25 +11,52 @@ import (
 
 // Top is an object.
 type Top struct {
-	// Bar:
-	Bar Sub `json:"bar,omitempty"`
+	// Arr:
+	Arr []Sub1 `json:"arr,omitempty"`
+	// Boo: Type alias for a value type
+	Boo bool `json:"boo,omitempty"`
+	// Obj:
+	Obj Sub1 `json:"obj,omitempty"`
 }
 
 // Validate implements basic validation for this model
 func (m Top) Validate() error {
 	return validation.Errors{
-		"bar": validation.Validate(
-			m.Bar,
+		"arr": validation.Validate(
+			m.Arr,
+		),
+		"obj": validation.Validate(
+			m.Obj,
 		),
 	}.Filter()
 }
 
-// GetBar returns the Bar property
-func (m Top) GetBar() Sub {
-	return m.Bar
+// GetArr returns the Arr property
+func (m Top) GetArr() []Sub1 {
+	return m.Arr
 }
 
-// SetBar sets the Bar property
-func (m Top) SetBar(val Sub) {
-	m.Bar = val
+// SetArr sets the Arr property
+func (m Top) SetArr(val []Sub1) {
+	m.Arr = val
+}
+
+// GetBoo returns the Boo property
+func (m Top) GetBoo() bool {
+	return m.Boo
+}
+
+// SetBoo sets the Boo property
+func (m Top) SetBoo(val bool) {
+	m.Boo = val
+}
+
+// GetObj returns the Obj property
+func (m Top) GetObj() Sub1 {
+	return m.Obj
+}
+
+// SetObj sets the Obj property
+func (m Top) SetObj(val Sub1) {
+	m.Obj = val
 }

--- a/pkg/generators/models/testdata/cases/embedded_type/generated/model_sub1.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/generated/model_sub1.go
@@ -1,0 +1,31 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Sub1 is an object.
+type Sub1 struct {
+	// Foo:
+	Foo string `json:"foo,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Sub1) Validate() error {
+	return validation.Errors{}.Filter()
+}
+
+// GetFoo returns the Foo property
+func (m Sub1) GetFoo() string {
+	return m.Foo
+}
+
+// SetFoo sets the Foo property
+func (m Sub1) SetFoo(val string) {
+	m.Foo = val
+}

--- a/pkg/generators/models/testdata/cases/embedded_type/generated/model_sub3.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/generated/model_sub3.go
@@ -1,0 +1,9 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+// Sub3 is a value type. Type alias for a value type
+type Sub3 bool

--- a/pkg/generators/models/testdata/cases/embedded_type/generated/model_top.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/generated/model_top.go
@@ -11,25 +11,52 @@ import (
 
 // Top is an object.
 type Top struct {
-	// Bar:
-	Bar Sub `json:"bar,omitempty"`
+	// Arr:
+	Arr []Sub1 `json:"arr,omitempty"`
+	// Boo: Type alias for a value type
+	Boo bool `json:"boo,omitempty"`
+	// Obj:
+	Obj Sub1 `json:"obj,omitempty"`
 }
 
 // Validate implements basic validation for this model
 func (m Top) Validate() error {
 	return validation.Errors{
-		"bar": validation.Validate(
-			m.Bar,
+		"arr": validation.Validate(
+			m.Arr,
+		),
+		"obj": validation.Validate(
+			m.Obj,
 		),
 	}.Filter()
 }
 
-// GetBar returns the Bar property
-func (m Top) GetBar() Sub {
-	return m.Bar
+// GetArr returns the Arr property
+func (m Top) GetArr() []Sub1 {
+	return m.Arr
 }
 
-// SetBar sets the Bar property
-func (m Top) SetBar(val Sub) {
-	m.Bar = val
+// SetArr sets the Arr property
+func (m Top) SetArr(val []Sub1) {
+	m.Arr = val
+}
+
+// GetBoo returns the Boo property
+func (m Top) GetBoo() bool {
+	return m.Boo
+}
+
+// SetBoo sets the Boo property
+func (m Top) SetBoo(val bool) {
+	m.Boo = val
+}
+
+// GetObj returns the Obj property
+func (m Top) GetObj() Sub1 {
+	return m.Obj
+}
+
+// SetObj sets the Obj property
+func (m Top) SetObj(val Sub1) {
+	m.Obj = val
 }


### PR DESCRIPTION
Now schemas which are extended aliases of value types are supported.
For example, you can define a schema which has `type: boolean` and then
refer to this schema from another schema. Before this caused a
generation error.


<!-- Summary of changes above here -->

## Ticket
<!-- Paste the url for the jira task/bug or Github issue here -->
No ticket, noticed the bug when worked on another task.

## How Has This Been Verified?
<!--- Please describe in detail how you tested your changes. -->
I modified an existing test case that now tests the new code.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [x] New code can be debugged via logs.
- [x] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
