### PR TITLE
fix: switch setter to use pointers

### DIFF
--- a/pkg/generators/models/templates.go
+++ b/pkg/generators/models/templates.go
@@ -97,7 +97,7 @@ func (m {{$modelName}}) Get{{.Name}}() {{.GoType}} {
 }
 
 // Set{{.Name}} sets the {{.Name}} property
-func (m {{$modelName}}) Set{{.Name}}(val {{.GoType}}) {
+func (m *{{$modelName}}) Set{{.Name}}(val {{.GoType}}) {
 	m.{{.Name}} = val
 }
 {{ end}}`

--- a/pkg/generators/models/testdata/cases/allof1/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof1/expected/model_foo.go
@@ -32,7 +32,7 @@ func (m Foo) GetBar() struct {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val struct {
+func (m *Foo) SetBar(val struct {
 	Bar string `json:"bar,omitempty"`
 	Foo string `json:"foo,omitempty"`
 }) {

--- a/pkg/generators/models/testdata/cases/allof1/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof1/generated/model_foo.go
@@ -32,7 +32,7 @@ func (m Foo) GetBar() struct {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val struct {
+func (m *Foo) SetBar(val struct {
 	Bar string `json:"bar,omitempty"`
 	Foo string `json:"foo,omitempty"`
 }) {

--- a/pkg/generators/models/testdata/cases/allof2/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof2/expected/model_foo.go
@@ -28,7 +28,7 @@ func (m Foo) GetBar() string {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val string) {
+func (m *Foo) SetBar(val string) {
 	m.Bar = val
 }
 
@@ -38,6 +38,6 @@ func (m Foo) GetFoo() string {
 }
 
 // SetFoo sets the Foo property
-func (m Foo) SetFoo(val string) {
+func (m *Foo) SetFoo(val string) {
 	m.Foo = val
 }

--- a/pkg/generators/models/testdata/cases/allof2/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof2/generated/model_foo.go
@@ -28,7 +28,7 @@ func (m Foo) GetBar() string {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val string) {
+func (m *Foo) SetBar(val string) {
 	m.Bar = val
 }
 
@@ -38,6 +38,6 @@ func (m Foo) GetFoo() string {
 }
 
 // SetFoo sets the Foo property
-func (m Foo) SetFoo(val string) {
+func (m *Foo) SetFoo(val string) {
 	m.Foo = val
 }

--- a/pkg/generators/models/testdata/cases/allof3/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof3/expected/model_foo.go
@@ -28,7 +28,7 @@ func (m Foo) GetMixin() string {
 }
 
 // SetMixin sets the Mixin property
-func (m Foo) SetMixin(val string) {
+func (m *Foo) SetMixin(val string) {
 	m.Mixin = val
 }
 
@@ -38,6 +38,6 @@ func (m Foo) GetSub() string {
 }
 
 // SetSub sets the Sub property
-func (m Foo) SetSub(val string) {
+func (m *Foo) SetSub(val string) {
 	m.Sub = val
 }

--- a/pkg/generators/models/testdata/cases/allof3/expected/model_sub.go
+++ b/pkg/generators/models/testdata/cases/allof3/expected/model_sub.go
@@ -26,6 +26,6 @@ func (m Sub) GetSub() string {
 }
 
 // SetSub sets the Sub property
-func (m Sub) SetSub(val string) {
+func (m *Sub) SetSub(val string) {
 	m.Sub = val
 }

--- a/pkg/generators/models/testdata/cases/allof3/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof3/generated/model_foo.go
@@ -28,7 +28,7 @@ func (m Foo) GetMixin() string {
 }
 
 // SetMixin sets the Mixin property
-func (m Foo) SetMixin(val string) {
+func (m *Foo) SetMixin(val string) {
 	m.Mixin = val
 }
 
@@ -38,6 +38,6 @@ func (m Foo) GetSub() string {
 }
 
 // SetSub sets the Sub property
-func (m Foo) SetSub(val string) {
+func (m *Foo) SetSub(val string) {
 	m.Sub = val
 }

--- a/pkg/generators/models/testdata/cases/allof3/generated/model_sub.go
+++ b/pkg/generators/models/testdata/cases/allof3/generated/model_sub.go
@@ -26,6 +26,6 @@ func (m Sub) GetSub() string {
 }
 
 // SetSub sets the Sub property
-func (m Sub) SetSub(val string) {
+func (m *Sub) SetSub(val string) {
 	m.Sub = val
 }

--- a/pkg/generators/models/testdata/cases/allof4/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof4/expected/model_foo.go
@@ -30,6 +30,6 @@ func (m Foo) GetBar() *Sub {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val *Sub) {
+func (m *Foo) SetBar(val *Sub) {
 	m.Bar = val
 }

--- a/pkg/generators/models/testdata/cases/allof4/expected/model_sub.go
+++ b/pkg/generators/models/testdata/cases/allof4/expected/model_sub.go
@@ -26,6 +26,6 @@ func (m Sub) GetSub() string {
 }
 
 // SetSub sets the Sub property
-func (m Sub) SetSub(val string) {
+func (m *Sub) SetSub(val string) {
 	m.Sub = val
 }

--- a/pkg/generators/models/testdata/cases/allof4/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof4/generated/model_foo.go
@@ -30,6 +30,6 @@ func (m Foo) GetBar() *Sub {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val *Sub) {
+func (m *Foo) SetBar(val *Sub) {
 	m.Bar = val
 }

--- a/pkg/generators/models/testdata/cases/allof4/generated/model_sub.go
+++ b/pkg/generators/models/testdata/cases/allof4/generated/model_sub.go
@@ -26,6 +26,6 @@ func (m Sub) GetSub() string {
 }
 
 // SetSub sets the Sub property
-func (m Sub) SetSub(val string) {
+func (m *Sub) SetSub(val string) {
 	m.Sub = val
 }

--- a/pkg/generators/models/testdata/cases/allof_arrays/expected/model_item.go
+++ b/pkg/generators/models/testdata/cases/allof_arrays/expected/model_item.go
@@ -26,6 +26,6 @@ func (m Item) GetFirst() string {
 }
 
 // SetFirst sets the First property
-func (m Item) SetFirst(val string) {
+func (m *Item) SetFirst(val string) {
 	m.First = val
 }

--- a/pkg/generators/models/testdata/cases/allof_arrays/expected/model_random.go
+++ b/pkg/generators/models/testdata/cases/allof_arrays/expected/model_random.go
@@ -30,6 +30,6 @@ func (m Random) GetList() []Item {
 }
 
 // SetList sets the List property
-func (m Random) SetList(val []Item) {
+func (m *Random) SetList(val []Item) {
 	m.List = val
 }

--- a/pkg/generators/models/testdata/cases/allof_arrays/generated/model_item.go
+++ b/pkg/generators/models/testdata/cases/allof_arrays/generated/model_item.go
@@ -26,6 +26,6 @@ func (m Item) GetFirst() string {
 }
 
 // SetFirst sets the First property
-func (m Item) SetFirst(val string) {
+func (m *Item) SetFirst(val string) {
 	m.First = val
 }

--- a/pkg/generators/models/testdata/cases/allof_arrays/generated/model_random.go
+++ b/pkg/generators/models/testdata/cases/allof_arrays/generated/model_random.go
@@ -30,6 +30,6 @@ func (m Random) GetList() []Item {
 }
 
 // SetList sets the List property
-func (m Random) SetList(val []Item) {
+func (m *Random) SetList(val []Item) {
 	m.List = val
 }

--- a/pkg/generators/models/testdata/cases/allof_enum/expected/model_artist.go
+++ b/pkg/generators/models/testdata/cases/allof_enum/expected/model_artist.go
@@ -35,7 +35,7 @@ func (m Artist) GetLeftHand() *AnyThing {
 }
 
 // SetLeftHand sets the LeftHand property
-func (m Artist) SetLeftHand(val *AnyThing) {
+func (m *Artist) SetLeftHand(val *AnyThing) {
 	m.LeftHand = val
 }
 
@@ -45,6 +45,6 @@ func (m Artist) GetRightHand() *Color {
 }
 
 // SetRightHand sets the RightHand property
-func (m Artist) SetRightHand(val *Color) {
+func (m *Artist) SetRightHand(val *Color) {
 	m.RightHand = val
 }

--- a/pkg/generators/models/testdata/cases/allof_enum/generated/model_artist.go
+++ b/pkg/generators/models/testdata/cases/allof_enum/generated/model_artist.go
@@ -35,7 +35,7 @@ func (m Artist) GetLeftHand() *AnyThing {
 }
 
 // SetLeftHand sets the LeftHand property
-func (m Artist) SetLeftHand(val *AnyThing) {
+func (m *Artist) SetLeftHand(val *AnyThing) {
 	m.LeftHand = val
 }
 
@@ -45,6 +45,6 @@ func (m Artist) GetRightHand() *Color {
 }
 
 // SetRightHand sets the RightHand property
-func (m Artist) SetRightHand(val *Color) {
+func (m *Artist) SetRightHand(val *Color) {
 	m.RightHand = val
 }

--- a/pkg/generators/models/testdata/cases/allof_merges_required_list/expected/model_base_entity.go
+++ b/pkg/generators/models/testdata/cases/allof_merges_required_list/expected/model_base_entity.go
@@ -33,7 +33,7 @@ func (m BaseEntity) GetId() string {
 }
 
 // SetId sets the Id property
-func (m BaseEntity) SetId(val string) {
+func (m *BaseEntity) SetId(val string) {
 	m.Id = val
 }
 
@@ -43,6 +43,6 @@ func (m BaseEntity) GetName() string {
 }
 
 // SetName sets the Name property
-func (m BaseEntity) SetName(val string) {
+func (m *BaseEntity) SetName(val string) {
 	m.Name = val
 }

--- a/pkg/generators/models/testdata/cases/allof_merges_required_list/expected/model_user_entity.go
+++ b/pkg/generators/models/testdata/cases/allof_merges_required_list/expected/model_user_entity.go
@@ -38,7 +38,7 @@ func (m UserEntity) GetEmail() string {
 }
 
 // SetEmail sets the Email property
-func (m UserEntity) SetEmail(val string) {
+func (m *UserEntity) SetEmail(val string) {
 	m.Email = val
 }
 
@@ -48,7 +48,7 @@ func (m UserEntity) GetId() string {
 }
 
 // SetId sets the Id property
-func (m UserEntity) SetId(val string) {
+func (m *UserEntity) SetId(val string) {
 	m.Id = val
 }
 
@@ -58,6 +58,6 @@ func (m UserEntity) GetName() string {
 }
 
 // SetName sets the Name property
-func (m UserEntity) SetName(val string) {
+func (m *UserEntity) SetName(val string) {
 	m.Name = val
 }

--- a/pkg/generators/models/testdata/cases/allof_merges_required_list/generated/model_base_entity.go
+++ b/pkg/generators/models/testdata/cases/allof_merges_required_list/generated/model_base_entity.go
@@ -33,7 +33,7 @@ func (m BaseEntity) GetId() string {
 }
 
 // SetId sets the Id property
-func (m BaseEntity) SetId(val string) {
+func (m *BaseEntity) SetId(val string) {
 	m.Id = val
 }
 
@@ -43,6 +43,6 @@ func (m BaseEntity) GetName() string {
 }
 
 // SetName sets the Name property
-func (m BaseEntity) SetName(val string) {
+func (m *BaseEntity) SetName(val string) {
 	m.Name = val
 }

--- a/pkg/generators/models/testdata/cases/allof_merges_required_list/generated/model_user_entity.go
+++ b/pkg/generators/models/testdata/cases/allof_merges_required_list/generated/model_user_entity.go
@@ -38,7 +38,7 @@ func (m UserEntity) GetEmail() string {
 }
 
 // SetEmail sets the Email property
-func (m UserEntity) SetEmail(val string) {
+func (m *UserEntity) SetEmail(val string) {
 	m.Email = val
 }
 
@@ -48,7 +48,7 @@ func (m UserEntity) GetId() string {
 }
 
 // SetId sets the Id property
-func (m UserEntity) SetId(val string) {
+func (m *UserEntity) SetId(val string) {
 	m.Id = val
 }
 
@@ -58,6 +58,6 @@ func (m UserEntity) GetName() string {
 }
 
 // SetName sets the Name property
-func (m UserEntity) SetName(val string) {
+func (m *UserEntity) SetName(val string) {
 	m.Name = val
 }

--- a/pkg/generators/models/testdata/cases/allof_self_reference/expected/model_list_item.go
+++ b/pkg/generators/models/testdata/cases/allof_self_reference/expected/model_list_item.go
@@ -32,7 +32,7 @@ func (m ListItem) GetNext() *ListItem {
 }
 
 // SetNext sets the Next property
-func (m ListItem) SetNext(val *ListItem) {
+func (m *ListItem) SetNext(val *ListItem) {
 	m.Next = val
 }
 
@@ -42,6 +42,6 @@ func (m ListItem) GetValue() string {
 }
 
 // SetValue sets the Value property
-func (m ListItem) SetValue(val string) {
+func (m *ListItem) SetValue(val string) {
 	m.Value = val
 }

--- a/pkg/generators/models/testdata/cases/allof_self_reference/generated/model_list_item.go
+++ b/pkg/generators/models/testdata/cases/allof_self_reference/generated/model_list_item.go
@@ -32,7 +32,7 @@ func (m ListItem) GetNext() *ListItem {
 }
 
 // SetNext sets the Next property
-func (m ListItem) SetNext(val *ListItem) {
+func (m *ListItem) SetNext(val *ListItem) {
 	m.Next = val
 }
 
@@ -42,6 +42,6 @@ func (m ListItem) GetValue() string {
 }
 
 // SetValue sets the Value property
-func (m ListItem) SetValue(val string) {
+func (m *ListItem) SetValue(val string) {
 	m.Value = val
 }

--- a/pkg/generators/models/testdata/cases/embedded_type/expected/model_sub1.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/expected/model_sub1.go
@@ -26,6 +26,6 @@ func (m Sub1) GetFoo() string {
 }
 
 // SetFoo sets the Foo property
-func (m Sub1) SetFoo(val string) {
+func (m *Sub1) SetFoo(val string) {
 	m.Foo = val
 }

--- a/pkg/generators/models/testdata/cases/embedded_type/expected/model_top.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/expected/model_top.go
@@ -37,7 +37,7 @@ func (m Top) GetArr() []Sub1 {
 }
 
 // SetArr sets the Arr property
-func (m Top) SetArr(val []Sub1) {
+func (m *Top) SetArr(val []Sub1) {
 	m.Arr = val
 }
 
@@ -47,7 +47,7 @@ func (m Top) GetBoo() bool {
 }
 
 // SetBoo sets the Boo property
-func (m Top) SetBoo(val bool) {
+func (m *Top) SetBoo(val bool) {
 	m.Boo = val
 }
 
@@ -57,6 +57,6 @@ func (m Top) GetObj() Sub1 {
 }
 
 // SetObj sets the Obj property
-func (m Top) SetObj(val Sub1) {
+func (m *Top) SetObj(val Sub1) {
 	m.Obj = val
 }

--- a/pkg/generators/models/testdata/cases/embedded_type/generated/model_sub1.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/generated/model_sub1.go
@@ -26,6 +26,6 @@ func (m Sub1) GetFoo() string {
 }
 
 // SetFoo sets the Foo property
-func (m Sub1) SetFoo(val string) {
+func (m *Sub1) SetFoo(val string) {
 	m.Foo = val
 }

--- a/pkg/generators/models/testdata/cases/embedded_type/generated/model_top.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/generated/model_top.go
@@ -37,7 +37,7 @@ func (m Top) GetArr() []Sub1 {
 }
 
 // SetArr sets the Arr property
-func (m Top) SetArr(val []Sub1) {
+func (m *Top) SetArr(val []Sub1) {
 	m.Arr = val
 }
 
@@ -47,7 +47,7 @@ func (m Top) GetBoo() bool {
 }
 
 // SetBoo sets the Boo property
-func (m Top) SetBoo(val bool) {
+func (m *Top) SetBoo(val bool) {
 	m.Boo = val
 }
 
@@ -57,6 +57,6 @@ func (m Top) GetObj() Sub1 {
 }
 
 // SetObj sets the Obj property
-func (m Top) SetObj(val Sub1) {
+func (m *Top) SetObj(val Sub1) {
 	m.Obj = val
 }

--- a/pkg/generators/models/testdata/cases/model_from_path_body/expected/model_my_op_body.go
+++ b/pkg/generators/models/testdata/cases/model_from_path_body/expected/model_my_op_body.go
@@ -26,6 +26,6 @@ func (m MyOpBody) GetFoo() string {
 }
 
 // SetFoo sets the Foo property
-func (m MyOpBody) SetFoo(val string) {
+func (m *MyOpBody) SetFoo(val string) {
 	m.Foo = val
 }

--- a/pkg/generators/models/testdata/cases/model_from_path_body/generated/model_my_op_body.go
+++ b/pkg/generators/models/testdata/cases/model_from_path_body/generated/model_my_op_body.go
@@ -26,6 +26,6 @@ func (m MyOpBody) GetFoo() string {
 }
 
 // SetFoo sets the Foo property
-func (m MyOpBody) SetFoo(val string) {
+func (m *MyOpBody) SetFoo(val string) {
 	m.Foo = val
 }

--- a/pkg/generators/models/testdata/cases/nullable_arrays/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_arrays/expected/model_foo.go
@@ -30,6 +30,6 @@ func (m Foo) GetBar() []string {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val []string) {
+func (m *Foo) SetBar(val []string) {
 	m.Bar = val
 }

--- a/pkg/generators/models/testdata/cases/nullable_arrays/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_arrays/generated/model_foo.go
@@ -30,6 +30,6 @@ func (m Foo) GetBar() []string {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val []string) {
+func (m *Foo) SetBar(val []string) {
 	m.Bar = val
 }

--- a/pkg/generators/models/testdata/cases/nullable_properties/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_properties/expected/model_foo.go
@@ -26,6 +26,6 @@ func (m Foo) GetBar() *string {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val *string) {
+func (m *Foo) SetBar(val *string) {
 	m.Bar = val
 }

--- a/pkg/generators/models/testdata/cases/nullable_properties/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_properties/generated/model_foo.go
@@ -26,6 +26,6 @@ func (m Foo) GetBar() *string {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val *string) {
+func (m *Foo) SetBar(val *string) {
 	m.Bar = val
 }

--- a/pkg/generators/models/testdata/cases/nullable_untyped_object/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_untyped_object/expected/model_foo.go
@@ -30,6 +30,6 @@ func (m Foo) GetBar() map[string]interface{} {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val map[string]interface{}) {
+func (m *Foo) SetBar(val map[string]interface{}) {
 	m.Bar = val
 }

--- a/pkg/generators/models/testdata/cases/nullable_untyped_object/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/nullable_untyped_object/generated/model_foo.go
@@ -30,6 +30,6 @@ func (m Foo) GetBar() map[string]interface{} {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val map[string]interface{}) {
+func (m *Foo) SetBar(val map[string]interface{}) {
 	m.Bar = val
 }

--- a/pkg/generators/models/testdata/cases/object_with_additional_properties/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/object_with_additional_properties/expected/model_foo.go
@@ -30,6 +30,6 @@ func (m Foo) GetFoo() map[string]string {
 }
 
 // SetFoo sets the Foo property
-func (m Foo) SetFoo(val map[string]string) {
+func (m *Foo) SetFoo(val map[string]string) {
 	m.Foo = val
 }

--- a/pkg/generators/models/testdata/cases/object_with_additional_properties/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/object_with_additional_properties/generated/model_foo.go
@@ -30,6 +30,6 @@ func (m Foo) GetFoo() map[string]string {
 }
 
 // SetFoo sets the Foo property
-func (m Foo) SetFoo(val map[string]string) {
+func (m *Foo) SetFoo(val map[string]string) {
 	m.Foo = val
 }

--- a/pkg/generators/models/testdata/cases/oneof/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/oneof/expected/model_foo.go
@@ -26,6 +26,6 @@ func (m Foo) GetBar() interface{} {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val interface{}) {
+func (m *Foo) SetBar(val interface{}) {
 	m.Bar = val
 }

--- a/pkg/generators/models/testdata/cases/oneof/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/oneof/generated/model_foo.go
@@ -26,6 +26,6 @@ func (m Foo) GetBar() interface{} {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val interface{}) {
+func (m *Foo) SetBar(val interface{}) {
 	m.Bar = val
 }

--- a/pkg/generators/models/testdata/cases/parameter_model/expected/model_get_foo_query_parameters.go
+++ b/pkg/generators/models/testdata/cases/parameter_model/expected/model_get_foo_query_parameters.go
@@ -51,7 +51,7 @@ func (m GetFooQueryParameters) GetParam1() string {
 }
 
 // SetParam1 sets the Param1 property
-func (m GetFooQueryParameters) SetParam1(val string) {
+func (m *GetFooQueryParameters) SetParam1(val string) {
 	m.Param1 = val
 }
 
@@ -61,7 +61,7 @@ func (m GetFooQueryParameters) GetId() string {
 }
 
 // SetId sets the Id property
-func (m GetFooQueryParameters) SetId(val string) {
+func (m *GetFooQueryParameters) SetId(val string) {
 	m.Id = val
 }
 
@@ -71,7 +71,7 @@ func (m GetFooQueryParameters) GetParam2() int32 {
 }
 
 // SetParam2 sets the Param2 property
-func (m GetFooQueryParameters) SetParam2(val int32) {
+func (m *GetFooQueryParameters) SetParam2(val int32) {
 	m.Param2 = val
 }
 
@@ -81,7 +81,7 @@ func (m GetFooQueryParameters) GetParam3() []string {
 }
 
 // SetParam3 sets the Param3 property
-func (m GetFooQueryParameters) SetParam3(val []string) {
+func (m *GetFooQueryParameters) SetParam3(val []string) {
 	m.Param3 = val
 }
 
@@ -91,6 +91,6 @@ func (m GetFooQueryParameters) GetPage() int32 {
 }
 
 // SetPage sets the Page property
-func (m GetFooQueryParameters) SetPage(val int32) {
+func (m *GetFooQueryParameters) SetPage(val int32) {
 	m.Page = val
 }

--- a/pkg/generators/models/testdata/cases/parameter_model/generated/model_get_foo_query_parameters.go
+++ b/pkg/generators/models/testdata/cases/parameter_model/generated/model_get_foo_query_parameters.go
@@ -51,7 +51,7 @@ func (m GetFooQueryParameters) GetParam1() string {
 }
 
 // SetParam1 sets the Param1 property
-func (m GetFooQueryParameters) SetParam1(val string) {
+func (m *GetFooQueryParameters) SetParam1(val string) {
 	m.Param1 = val
 }
 
@@ -61,7 +61,7 @@ func (m GetFooQueryParameters) GetId() string {
 }
 
 // SetId sets the Id property
-func (m GetFooQueryParameters) SetId(val string) {
+func (m *GetFooQueryParameters) SetId(val string) {
 	m.Id = val
 }
 
@@ -71,7 +71,7 @@ func (m GetFooQueryParameters) GetParam2() int32 {
 }
 
 // SetParam2 sets the Param2 property
-func (m GetFooQueryParameters) SetParam2(val int32) {
+func (m *GetFooQueryParameters) SetParam2(val int32) {
 	m.Param2 = val
 }
 
@@ -81,7 +81,7 @@ func (m GetFooQueryParameters) GetParam3() []string {
 }
 
 // SetParam3 sets the Param3 property
-func (m GetFooQueryParameters) SetParam3(val []string) {
+func (m *GetFooQueryParameters) SetParam3(val []string) {
 	m.Param3 = val
 }
 
@@ -91,6 +91,6 @@ func (m GetFooQueryParameters) GetPage() int32 {
 }
 
 // SetPage sets the Page property
-func (m GetFooQueryParameters) SetPage(val int32) {
+func (m *GetFooQueryParameters) SetPage(val int32) {
 	m.Page = val
 }

--- a/pkg/generators/models/testdata/cases/required_properties/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/required_properties/expected/model_foo.go
@@ -26,6 +26,6 @@ func (m Foo) GetBar() string {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val string) {
+func (m *Foo) SetBar(val string) {
 	m.Bar = val
 }

--- a/pkg/generators/models/testdata/cases/required_properties/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/required_properties/generated/model_foo.go
@@ -26,6 +26,6 @@ func (m Foo) GetBar() string {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val string) {
+func (m *Foo) SetBar(val string) {
 	m.Bar = val
 }

--- a/pkg/generators/models/testdata/cases/simple_model/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/simple_model/expected/model_foo.go
@@ -26,6 +26,6 @@ func (m Foo) GetBar() string {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val string) {
+func (m *Foo) SetBar(val string) {
 	m.Bar = val
 }

--- a/pkg/generators/models/testdata/cases/simple_model/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/simple_model/generated/model_foo.go
@@ -26,6 +26,6 @@ func (m Foo) GetBar() string {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val string) {
+func (m *Foo) SetBar(val string) {
 	m.Bar = val
 }

--- a/pkg/generators/models/testdata/cases/typed_arrays/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/typed_arrays/expected/model_foo.go
@@ -30,6 +30,6 @@ func (m Foo) GetBar() []string {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val []string) {
+func (m *Foo) SetBar(val []string) {
 	m.Bar = val
 }

--- a/pkg/generators/models/testdata/cases/typed_arrays/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/typed_arrays/generated/model_foo.go
@@ -30,6 +30,6 @@ func (m Foo) GetBar() []string {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val []string) {
+func (m *Foo) SetBar(val []string) {
 	m.Bar = val
 }

--- a/pkg/generators/models/testdata/cases/untyped_object/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/untyped_object/expected/model_foo.go
@@ -30,6 +30,6 @@ func (m Foo) GetBar() map[string]interface{} {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val map[string]interface{}) {
+func (m *Foo) SetBar(val map[string]interface{}) {
 	m.Bar = val
 }

--- a/pkg/generators/models/testdata/cases/untyped_object/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/untyped_object/generated/model_foo.go
@@ -30,6 +30,6 @@ func (m Foo) GetBar() map[string]interface{} {
 }
 
 // SetBar sets the Bar property
-func (m Foo) SetBar(val map[string]interface{}) {
+func (m *Foo) SetBar(val map[string]interface{}) {
 	m.Bar = val
 }

--- a/pkg/generators/models/testdata/cases/update.sh
+++ b/pkg/generators/models/testdata/cases/update.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+for case in $(ls)
+do
+	if [ -d $case ];
+	then
+		cd $case
+		rm -rf expected
+		cp -r generated expected
+		echo "updated $case"
+		cd ..
+	fi
+done

--- a/pkg/generators/models/testdata/cases/validation/expected/model_address.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_address.go
@@ -37,7 +37,7 @@ func (m Address) GetName() *string {
 }
 
 // SetName sets the Name property
-func (m Address) SetName(val *string) {
+func (m *Address) SetName(val *string) {
 	m.Name = val
 }
 
@@ -47,7 +47,7 @@ func (m Address) GetNumber() int32 {
 }
 
 // SetNumber sets the Number property
-func (m Address) SetNumber(val int32) {
+func (m *Address) SetNumber(val int32) {
 	m.Number = val
 }
 
@@ -57,6 +57,6 @@ func (m Address) GetStreet() string {
 }
 
 // SetStreet sets the Street property
-func (m Address) SetStreet(val string) {
+func (m *Address) SetStreet(val string) {
 	m.Street = val
 }

--- a/pkg/generators/models/testdata/cases/validation/expected/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_person.go
@@ -112,7 +112,7 @@ func (m Person) GetAddress() Address {
 }
 
 // SetAddress sets the Address property
-func (m Person) SetAddress(val Address) {
+func (m *Person) SetAddress(val Address) {
 	m.Address = val
 }
 
@@ -122,7 +122,7 @@ func (m Person) GetAge() float32 {
 }
 
 // SetAge sets the Age property
-func (m Person) SetAge(val float32) {
+func (m *Person) SetAge(val float32) {
 	m.Age = val
 }
 
@@ -132,7 +132,7 @@ func (m Person) GetBase64() string {
 }
 
 // SetBase64 sets the Base64 property
-func (m Person) SetBase64(val string) {
+func (m *Person) SetBase64(val string) {
 	m.Base64 = val
 }
 
@@ -142,7 +142,7 @@ func (m Person) GetDate() string {
 }
 
 // SetDate sets the Date property
-func (m Person) SetDate(val string) {
+func (m *Person) SetDate(val string) {
 	m.Date = val
 }
 
@@ -152,7 +152,7 @@ func (m Person) GetDatetime() time.Time {
 }
 
 // SetDatetime sets the Datetime property
-func (m Person) SetDatetime(val time.Time) {
+func (m *Person) SetDatetime(val time.Time) {
 	m.Datetime = val
 }
 
@@ -162,7 +162,7 @@ func (m Person) GetEmail() string {
 }
 
 // SetEmail sets the Email property
-func (m Person) SetEmail(val string) {
+func (m *Person) SetEmail(val string) {
 	m.Email = val
 }
 
@@ -172,7 +172,7 @@ func (m Person) GetFavoriteColors() []Color {
 }
 
 // SetFavoriteColors sets the FavoriteColors property
-func (m Person) SetFavoriteColors(val []Color) {
+func (m *Person) SetFavoriteColors(val []Color) {
 	m.FavoriteColors = val
 }
 
@@ -182,7 +182,7 @@ func (m Person) GetGender() Gender {
 }
 
 // SetGender sets the Gender property
-func (m Person) SetGender(val Gender) {
+func (m *Person) SetGender(val Gender) {
 	m.Gender = val
 }
 
@@ -192,7 +192,7 @@ func (m Person) GetHostname() string {
 }
 
 // SetHostname sets the Hostname property
-func (m Person) SetHostname(val string) {
+func (m *Person) SetHostname(val string) {
 	m.Hostname = val
 }
 
@@ -202,7 +202,7 @@ func (m Person) GetIp() string {
 }
 
 // SetIp sets the Ip property
-func (m Person) SetIp(val string) {
+func (m *Person) SetIp(val string) {
 	m.Ip = val
 }
 
@@ -212,7 +212,7 @@ func (m Person) GetIpv4() string {
 }
 
 // SetIpv4 sets the Ipv4 property
-func (m Person) SetIpv4(val string) {
+func (m *Person) SetIpv4(val string) {
 	m.Ipv4 = val
 }
 
@@ -222,7 +222,7 @@ func (m Person) GetIpv6() string {
 }
 
 // SetIpv6 sets the Ipv6 property
-func (m Person) SetIpv6(val string) {
+func (m *Person) SetIpv6(val string) {
 	m.Ipv6 = val
 }
 
@@ -232,7 +232,7 @@ func (m Person) GetName() string {
 }
 
 // SetName sets the Name property
-func (m Person) SetName(val string) {
+func (m *Person) SetName(val string) {
 	m.Name = val
 }
 
@@ -242,7 +242,7 @@ func (m Person) GetRequestURI() string {
 }
 
 // SetRequestURI sets the RequestURI property
-func (m Person) SetRequestURI(val string) {
+func (m *Person) SetRequestURI(val string) {
 	m.RequestURI = val
 }
 
@@ -252,7 +252,7 @@ func (m Person) GetSecondGender() *Gender {
 }
 
 // SetSecondGender sets the SecondGender property
-func (m Person) SetSecondGender(val *Gender) {
+func (m *Person) SetSecondGender(val *Gender) {
 	m.SecondGender = val
 }
 
@@ -262,7 +262,7 @@ func (m Person) GetUri() string {
 }
 
 // SetUri sets the Uri property
-func (m Person) SetUri(val string) {
+func (m *Person) SetUri(val string) {
 	m.Uri = val
 }
 
@@ -272,7 +272,7 @@ func (m Person) GetUrl() string {
 }
 
 // SetUrl sets the Url property
-func (m Person) SetUrl(val string) {
+func (m *Person) SetUrl(val string) {
 	m.Url = val
 }
 
@@ -282,6 +282,6 @@ func (m Person) GetUuid() string {
 }
 
 // SetUuid sets the Uuid property
-func (m Person) SetUuid(val string) {
+func (m *Person) SetUuid(val string) {
 	m.Uuid = val
 }

--- a/pkg/generators/models/testdata/cases/validation/generated/model_address.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_address.go
@@ -37,7 +37,7 @@ func (m Address) GetName() *string {
 }
 
 // SetName sets the Name property
-func (m Address) SetName(val *string) {
+func (m *Address) SetName(val *string) {
 	m.Name = val
 }
 
@@ -47,7 +47,7 @@ func (m Address) GetNumber() int32 {
 }
 
 // SetNumber sets the Number property
-func (m Address) SetNumber(val int32) {
+func (m *Address) SetNumber(val int32) {
 	m.Number = val
 }
 
@@ -57,6 +57,6 @@ func (m Address) GetStreet() string {
 }
 
 // SetStreet sets the Street property
-func (m Address) SetStreet(val string) {
+func (m *Address) SetStreet(val string) {
 	m.Street = val
 }

--- a/pkg/generators/models/testdata/cases/validation/generated/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_person.go
@@ -112,7 +112,7 @@ func (m Person) GetAddress() Address {
 }
 
 // SetAddress sets the Address property
-func (m Person) SetAddress(val Address) {
+func (m *Person) SetAddress(val Address) {
 	m.Address = val
 }
 
@@ -122,7 +122,7 @@ func (m Person) GetAge() float32 {
 }
 
 // SetAge sets the Age property
-func (m Person) SetAge(val float32) {
+func (m *Person) SetAge(val float32) {
 	m.Age = val
 }
 
@@ -132,7 +132,7 @@ func (m Person) GetBase64() string {
 }
 
 // SetBase64 sets the Base64 property
-func (m Person) SetBase64(val string) {
+func (m *Person) SetBase64(val string) {
 	m.Base64 = val
 }
 
@@ -142,7 +142,7 @@ func (m Person) GetDate() string {
 }
 
 // SetDate sets the Date property
-func (m Person) SetDate(val string) {
+func (m *Person) SetDate(val string) {
 	m.Date = val
 }
 
@@ -152,7 +152,7 @@ func (m Person) GetDatetime() time.Time {
 }
 
 // SetDatetime sets the Datetime property
-func (m Person) SetDatetime(val time.Time) {
+func (m *Person) SetDatetime(val time.Time) {
 	m.Datetime = val
 }
 
@@ -162,7 +162,7 @@ func (m Person) GetEmail() string {
 }
 
 // SetEmail sets the Email property
-func (m Person) SetEmail(val string) {
+func (m *Person) SetEmail(val string) {
 	m.Email = val
 }
 
@@ -172,7 +172,7 @@ func (m Person) GetFavoriteColors() []Color {
 }
 
 // SetFavoriteColors sets the FavoriteColors property
-func (m Person) SetFavoriteColors(val []Color) {
+func (m *Person) SetFavoriteColors(val []Color) {
 	m.FavoriteColors = val
 }
 
@@ -182,7 +182,7 @@ func (m Person) GetGender() Gender {
 }
 
 // SetGender sets the Gender property
-func (m Person) SetGender(val Gender) {
+func (m *Person) SetGender(val Gender) {
 	m.Gender = val
 }
 
@@ -192,7 +192,7 @@ func (m Person) GetHostname() string {
 }
 
 // SetHostname sets the Hostname property
-func (m Person) SetHostname(val string) {
+func (m *Person) SetHostname(val string) {
 	m.Hostname = val
 }
 
@@ -202,7 +202,7 @@ func (m Person) GetIp() string {
 }
 
 // SetIp sets the Ip property
-func (m Person) SetIp(val string) {
+func (m *Person) SetIp(val string) {
 	m.Ip = val
 }
 
@@ -212,7 +212,7 @@ func (m Person) GetIpv4() string {
 }
 
 // SetIpv4 sets the Ipv4 property
-func (m Person) SetIpv4(val string) {
+func (m *Person) SetIpv4(val string) {
 	m.Ipv4 = val
 }
 
@@ -222,7 +222,7 @@ func (m Person) GetIpv6() string {
 }
 
 // SetIpv6 sets the Ipv6 property
-func (m Person) SetIpv6(val string) {
+func (m *Person) SetIpv6(val string) {
 	m.Ipv6 = val
 }
 
@@ -232,7 +232,7 @@ func (m Person) GetName() string {
 }
 
 // SetName sets the Name property
-func (m Person) SetName(val string) {
+func (m *Person) SetName(val string) {
 	m.Name = val
 }
 
@@ -242,7 +242,7 @@ func (m Person) GetRequestURI() string {
 }
 
 // SetRequestURI sets the RequestURI property
-func (m Person) SetRequestURI(val string) {
+func (m *Person) SetRequestURI(val string) {
 	m.RequestURI = val
 }
 
@@ -252,7 +252,7 @@ func (m Person) GetSecondGender() *Gender {
 }
 
 // SetSecondGender sets the SecondGender property
-func (m Person) SetSecondGender(val *Gender) {
+func (m *Person) SetSecondGender(val *Gender) {
 	m.SecondGender = val
 }
 
@@ -262,7 +262,7 @@ func (m Person) GetUri() string {
 }
 
 // SetUri sets the Uri property
-func (m Person) SetUri(val string) {
+func (m *Person) SetUri(val string) {
 	m.Uri = val
 }
 
@@ -272,7 +272,7 @@ func (m Person) GetUrl() string {
 }
 
 // SetUrl sets the Url property
-func (m Person) SetUrl(val string) {
+func (m *Person) SetUrl(val string) {
 	m.Url = val
 }
 
@@ -282,6 +282,6 @@ func (m Person) GetUuid() string {
 }
 
 // SetUuid sets the Uuid property
-func (m Person) SetUuid(val string) {
+func (m *Person) SetUuid(val string) {
 	m.Uuid = val
 }


### PR DESCRIPTION
Before this change all the generated model setter were noop. They set
values to the struct copy not the struct itself and since that copy
was never returned they were noop.

Also, added an update script for replacing expected models in the test
cases but with the great power comes great responsibility, so review
the overwrites carefully.


<!-- Summary of changes above here -->

## Ticket
<!-- Paste the url for the jira task/bug or Github issue here -->
No ticket, found this bug when working on another thing.

## How Has This Been Verified?
<!--- Please describe in detail how you tested your changes. -->
I reviewed all the test changes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [ ] New code can be debugged via logs.
- [ ] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
