### PR TITLE
fix: make toplevel oneofs translate to empty interface instead of object

### DIFF
--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -122,10 +122,7 @@ func NewModelFromRef(ref *openapi3.SchemaRef) (model *Model, err error) {
 		model.Properties, err = enumPropsFromRef(ref, model)
 		model.GoType = goTypeFromSpec(ref)
 
-	case ref.Value.Type == "object" ||
-		len(ref.Value.Properties) > 0 ||
-		len(ref.Value.AllOf) > 0 ||
-		len(ref.Value.OneOf) > 0:
+	case ref.Value.Type == "object" || len(ref.Value.Properties) > 0:
 		model.Kind = Struct
 		model.Properties, model.Imports, err = structPropsFromRef(ref)
 		if len(model.Properties) == 0 {

--- a/pkg/generators/models/testdata/cases/oneof/api.yaml
+++ b/pkg/generators/models/testdata/cases/oneof/api.yaml
@@ -12,3 +12,8 @@ components:
           oneOf:
             - type: string
             - type: integer
+    Bar:
+      oneOf:
+        - type: string
+        - type: integer
+      

--- a/pkg/generators/models/testdata/cases/oneof/expected/model_bar.go
+++ b/pkg/generators/models/testdata/cases/oneof/expected/model_bar.go
@@ -1,0 +1,9 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+// Bar is a value type.
+type Bar interface{}

--- a/pkg/generators/models/testdata/cases/oneof/generated/model_bar.go
+++ b/pkg/generators/models/testdata/cases/oneof/generated/model_bar.go
@@ -1,0 +1,9 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+// Bar is a value type.
+type Bar interface{}


### PR DESCRIPTION
fix: use interface for oneOf
    the map is the incorrect format for a oneof of primitave values, interface is easier to workwith
fix: do not use map[string]interface fallback for allOf
    allOf has improved and proper support now, so this fallback is not needed

## Ticket
<!-- Paste the url for the jira task/bug or Github issue here -->

## How Has This Been Verified?
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The change works as expected.
- [ ] New code can be debugged via logs.
- [ ] I have added tests to cover my changes.
- [ ] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
