### PR TITLE
fix: Allow responses section in components to be omitted

### DIFF
--- a/pkg/filters/openapi.go
+++ b/pkg/filters/openapi.go
@@ -59,9 +59,14 @@ func ByPath(file io.Reader, allowedPaths []string) (filteredSpec []byte, err err
 		return filteredSpec, fmt.Errorf("`schemas` is invalid type")
 	}
 
-	responses, ok := components["responses"].(Entry)
-	if !ok {
-		return filteredSpec, fmt.Errorf("`responses` is invalid type")
+	// responses are optional
+	var responses Entry
+	r := components["responses"]
+	if r != nil {
+		responses, ok = r.(Entry)
+		if !ok {
+			return filteredSpec, fmt.Errorf("`responses` is invalid type")
+		}
 	}
 
 	// filter out extra endpoints

--- a/pkg/filters/openapi_test.go
+++ b/pkg/filters/openapi_test.go
@@ -14,25 +14,34 @@ func TestFilterByPath(t *testing.T) {
 
 	cases := []struct {
 		name    string
+		source  string
 		filters []string
 	}{
 		{
-			name: "empty filter list",
+			name:   "empty filter list",
+			source: "source.yaml",
 		},
 		{
 			name:    "filter with single path",
+			source:  "source.yaml",
 			filters: []string{"/api/v2/{projectId}/fields"},
 		},
 		{
 			name:    "filter with multiple paths",
+			source:  "source.yaml",
 			filters: []string{"/api/v2/{projectId}/fields", "/api/v2/{projectId}/field-sets/{resourceKind}"},
+		},
+		{
+			name:    "filter without responses component",
+			source:  "source_without_responses_component.yaml",
+			filters: []string{"/api/v2/{projectId}/fields"},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			sourceFile, err := os.Open(filepath.Join("testdata", "source.yaml"))
+			sourceFile, err := os.Open(filepath.Join("testdata", tc.source))
 			require.NoError(t, err)
 
 			out, err := ByPath(sourceFile, tc.filters)
@@ -42,7 +51,7 @@ func TestFilterByPath(t *testing.T) {
 			exp, err := ioutil.ReadFile(filepath.Join("testdata", testFolder, "out.yaml"))
 			require.NoError(t, err)
 
-			require.YAMLEq(t, string(exp), string(out))
+			require.YAMLEq(t, string(exp), string(out), string(out))
 		})
 	}
 }

--- a/pkg/filters/testdata/filter_without_responses_component/filter.txt
+++ b/pkg/filters/testdata/filter_without_responses_component/filter.txt
@@ -1,0 +1,1 @@
+/api/v2/{projectId}/fields

--- a/pkg/filters/testdata/filter_without_responses_component/out.yaml
+++ b/pkg/filters/testdata/filter_without_responses_component/out.yaml
@@ -1,0 +1,320 @@
+components:
+  schemas:
+    CreateCustomFieldRequest:
+      properties:
+        description:
+          description: |
+            A description of the purpose of this field
+          maxLength: 255
+          type: string
+        displayName:
+          description: |
+            A nice human-readable name for that field
+          type: string
+        filterable:
+          default: false
+          description: |
+            Should this field show up as a filter in the catalog
+          type: boolean
+        hideIfEmpty:
+          default: false
+          description: |
+            Should this field be hidden when its value is empty
+          type: boolean
+        maxValue:
+          nullable: true
+          type: number
+        minValue:
+          nullable: true
+          type: number
+        name:
+          description: |
+            A nice computer-readable name for that field usable in postgres
+          type: string
+        searchable:
+          default: false
+          description: |
+            Should this field be used in the catalog fuzzy search
+          type: boolean
+        type:
+          $ref: '#/components/schemas/FieldType'
+        validValues:
+          items:
+            type: string
+          type: array
+      required:
+        - type
+        - name
+        - filterable
+        - searchable
+        - hideIfEmpty
+      type: object
+    FieldKind:
+      description: |
+        The source type of the field.
+
+        - System fields are non-editable default fields.  These can not be modified for deleted.
+
+        - Configurable fields are editable default fields. These can be modified but not deleted.
+
+        - Custom are user defined fields. These are fully defined by the user.
+      enum:
+        - system
+        - configurable
+        - custom
+      readOnly: true
+      type: string
+    FieldSpec:
+      properties:
+        description:
+          description: |
+            A description of the purpose of this field
+          maxLength: 255
+          type: string
+        displayName:
+          description: |
+            A nice human-readable name for that field
+          type: string
+        filterable:
+          default: false
+          description: |
+            Should this field show up as a filter in the catalog
+          type: boolean
+        hideIfEmpty:
+          default: false
+          description: |
+            Should this field be hidden when the value is empty
+          type: boolean
+        inherited:
+          default: false
+          description: |
+            Indicates that this field may be inherited from the parent resource
+          type: boolean
+        key:
+          description: |
+            lookup key for the field on the specific response types in dot notation.
+            Examples:
+              `name` -> name is found toplevel of the instance object, i.e. `obj.name`
+              `properties.category` -> category is found in the properties subobject, i.e. `obj.properties.category`
+          type: string
+        kind:
+          $ref: '#/components/schemas/FieldKind'
+        maxValue:
+          nullable: true
+          type: number
+        minValue:
+          nullable: true
+          type: number
+        name:
+          description: |
+            A nice computer-readable name for that field usable in postgres
+          type: string
+        searchable:
+          default: false
+          description: |
+            Should this field be used in the catalog fuzzy search
+          type: boolean
+        type:
+          $ref: '#/components/schemas/FieldType'
+        validValues:
+          items:
+            type: string
+          type: array
+      required:
+        - name
+        - key
+        - type
+        - kind
+        - filterable
+        - searchable
+        - description
+        - hideIfEmpty
+        - inherited
+      type: object
+    FieldType:
+      description: |
+        The data type of the field:
+
+        - `text` is an arbitrary string
+
+        - `multitext` is an arbitrary array of strings
+
+        - `select` a value which can be selected from a list
+
+        - `multiselect` is a `select` with multiple selected values, represented as an array
+
+        - `boolean` is `true` or `false` value
+
+        - `date` is a date string in `yyyy-mm-dd` format, e.g. `2019-08-21`
+
+        - `datetime` is an RFC3339 datetime string, e.g. `2019-08-21T11:54:30.369917Z`
+
+        - `number` is a numeric value, described by RFC8259, section 6.
+
+        - `link` is a link object with a displayed text and URL, e.g. `{"displayText": "text", "url": "http://example.com"}`. Only absolute URLs with HTTP/HTTPS protocol are allowed.
+      enum:
+        - text
+        - multitext
+        - select
+        - multiselect
+        - boolean
+        - date
+        - datetime
+        - number
+        - link
+      type: string
+    PageInfo:
+      description: Contains the pagination metadata for a response
+      properties:
+        current:
+          description: The current page number using 1-based array indexing
+          type: integer
+        itemCount:
+          description: Total number of items
+          type: integer
+        itemsPerPage:
+          description: |
+            Maximum items that can be on the page. They may be different from
+            the requested number of times
+          type: integer
+        unfilteredItemCount:
+          description: Item count if filters were not applied
+          type: integer
+      required:
+        - itemCount
+        - itemsPerPage
+        - unfilteredItemCount
+        - current
+      type: object
+    PagedCustomFieldResponse:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/FieldSpec'
+          type: array
+        page:
+          $ref: '#/components/schemas/PageInfo'
+      required:
+        - page
+        - data
+      type: object
+    ResourceKind:
+      description: A list of supported resource kinds
+      enum:
+        - datasource
+        - table
+        - column
+        - usecase
+        - bireport
+        - glossaryitem
+        - application
+        - pipeline
+        - api
+        - model
+        - stream
+        - filestorage
+      type: string
+  securitySchemes:
+    doubleCookieAuth:
+      description: Cookie value set during login, automatically sent by the browser
+      in: header
+      name: double-cookie
+      type: apiKey
+    doubleCookieHeader:
+      in: header
+      name: X-Double-Cookie
+      type: apiKey
+    tokenAuth:
+      bearerFormat: Personal Access Token or Service Account Token
+      scheme: bearer
+      type: http
+info:
+  contact:
+    email: developer@contiamo.com
+  description: Fields API
+  title: Fields Service
+  version: 0.2.0
+openapi: 3.0.0
+paths:
+  /api/v2/{projectId}/fields:
+    get:
+      operationId: ListCustomFields
+      parameters:
+        - description: Search fields by name and description
+          in: query
+          name: search
+          schema:
+            type: string
+        - description: Filter the response to only those unassigned for the named kind
+          in: query
+          name: unassigned
+          schema:
+            $ref: '#/components/schemas/ResourceKind'
+        - description: The current set of paged results to display, based on a 1-based array index
+          in: query
+          name: page
+          schema:
+            type: integer
+        - description: Maximum items to return in the response per page
+          in: query
+          name: pageSize
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 5
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedCustomFieldResponse'
+          description: Here are the fields
+      summary: List the available custom Fields
+      tags:
+        - fields
+      x-handler-group: FieldsV2
+    parameters:
+      - description: UUID of the project
+        in: path
+        name: projectId
+        required: true
+        schema:
+          format: uuid
+          type: string
+    post:
+      operationId: CreateCustomField
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCustomFieldRequest'
+        description: The fields spec to set
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FieldSpec'
+          description: Successfully create the Field
+      summary: Create new custom Field
+      tags:
+        - fields
+      x-handler-group: FieldsV2
+security:
+  - tokenAuth: []
+servers:
+  - description: Locally running
+    url: http://localhost:{port}
+    variables:
+      port:
+        default: "9191"
+  - description: Production environment
+    url: https://cloud.example.com/{tenantId}
+    variables:
+      tenantId:
+        default: demo
+tags:
+  - description: Endpoints for managing the catalog structure
+    name: fields

--- a/pkg/filters/testdata/source_without_responses_component.yaml
+++ b/pkg/filters/testdata/source_without_responses_component.yaml
@@ -1,0 +1,693 @@
+openapi: 3.0.0
+info:
+  contact:
+    email: developer@contiamo.com
+  description: Fields API
+  title: Fields Service
+  version: 0.2.0
+components:
+  schemas:
+    CreateCustomFieldRequest:
+      properties:
+        description:
+          description: |
+            A description of the purpose of this field
+          maxLength: 255
+          type: string
+        displayName:
+          description: |
+            A nice human-readable name for that field
+          type: string
+        filterable:
+          default: false
+          description: |
+            Should this field show up as a filter in the catalog
+          type: boolean
+        hideIfEmpty:
+          default: false
+          description: |
+            Should this field be hidden when its value is empty
+          type: boolean
+        maxValue:
+          nullable: true
+          type: number
+        minValue:
+          nullable: true
+          type: number
+        name:
+          description: |
+            A nice computer-readable name for that field usable in postgres
+          type: string
+        searchable:
+          default: false
+          description: |
+            Should this field be used in the catalog fuzzy search
+          type: boolean
+        type:
+          $ref: '#/components/schemas/FieldType'
+        validValues:
+          items:
+            type: string
+          type: array
+      required:
+        - type
+        - name
+        - filterable
+        - searchable
+        - hideIfEmpty
+      type: object
+    FieldError:
+      properties:
+        key:
+          type: string
+        message:
+          type: string
+        type:
+          $ref: '#/components/schemas/FieldErrorType'
+      required:
+        - type
+        - key
+        - message
+      type: object
+    FieldErrorResponse:
+      description: Error message that contains detailed information about certain parameters being incorrect
+      properties:
+        errors:
+          items:
+            $ref: '#/components/schemas/FieldError'
+          type: array
+      required:
+        - errors
+      type: object
+    FieldErrorType:
+      description: The type of the field error response
+      enum:
+        - FieldError
+      type: string
+    FieldKind:
+      description: |
+        The source type of the field.
+
+        - System fields are non-editable default fields.  These can not be modified for deleted.
+
+        - Configurable fields are editable default fields. These can be modified but not deleted.
+
+        - Custom are user defined fields. These are fully defined by the user.
+      enum:
+        - system
+        - configurable
+        - custom
+      readOnly: true
+      type: string
+    FieldSpec:
+      properties:
+        description:
+          description: |
+            A description of the purpose of this field
+          maxLength: 255
+          type: string
+        displayName:
+          description: |
+            A nice human-readable name for that field
+          type: string
+        filterable:
+          default: false
+          description: |
+            Should this field show up as a filter in the catalog
+          type: boolean
+        hideIfEmpty:
+          default: false
+          description: |
+            Should this field be hidden when the value is empty
+          type: boolean
+        inherited:
+          default: false
+          description: |
+            Indicates that this field may be inherited from the parent resource
+          type: boolean
+        key:
+          description: |
+            lookup key for the field on the specific response types in dot notation.
+            Examples:
+              `name` -> name is found toplevel of the instance object, i.e. `obj.name`
+              `properties.category` -> category is found in the properties subobject, i.e. `obj.properties.category`
+          type: string
+        kind:
+          $ref: '#/components/schemas/FieldKind'
+        maxValue:
+          nullable: true
+          type: number
+        minValue:
+          nullable: true
+          type: number
+        name:
+          description: |
+            A nice computer-readable name for that field usable in postgres
+          type: string
+        searchable:
+          default: false
+          description: |
+            Should this field be used in the catalog fuzzy search
+          type: boolean
+        type:
+          $ref: '#/components/schemas/FieldType'
+        validValues:
+          items:
+            type: string
+          type: array
+      required:
+        - name
+        - key
+        - type
+        - kind
+        - filterable
+        - searchable
+        - description
+        - hideIfEmpty
+        - inherited
+      type: object
+    FieldSpecUpdateRequest:
+      properties:
+        description:
+          description: |
+            A description of the purpose of this field
+          maxLength: 255
+          type: string
+        displayName:
+          description: |
+            A nice human-readable name for that field
+          type: string
+        filterable:
+          default: false
+          description: |
+            Should this field show up as a filter in the catalog
+          type: boolean
+        kind:
+          $ref: '#/components/schemas/FieldKind'
+        maxValue:
+          nullable: true
+          type: number
+        minValue:
+          nullable: true
+          type: number
+        name:
+          description: |
+            A nice computer-readable name for that field usable in postgres
+          type: string
+        searchable:
+          default: false
+          description: |
+            Should this field be used in the catalog fuzzy search
+          type: boolean
+        type:
+          $ref: '#/components/schemas/FieldType'
+        validValues:
+          items:
+            type: string
+          type: array
+      required:
+        - name
+        - type
+        - kind
+        - filterable
+        - searchable
+        - description
+      type: object
+    FieldType:
+      description: |
+        The data type of the field:
+
+        - `text` is an arbitrary string
+
+        - `multitext` is an arbitrary array of strings
+
+        - `select` a value which can be selected from a list
+
+        - `multiselect` is a `select` with multiple selected values, represented as an array
+
+        - `boolean` is `true` or `false` value
+
+        - `date` is a date string in `yyyy-mm-dd` format, e.g. `2019-08-21`
+
+        - `datetime` is an RFC3339 datetime string, e.g. `2019-08-21T11:54:30.369917Z`
+
+        - `number` is a numeric value, described by RFC8259, section 6.
+
+        - `link` is a link object with a displayed text and URL, e.g. `{"displayText": "text", "url": "http://example.com"}`. Only absolute URLs with HTTP/HTTPS protocol are allowed.
+      enum:
+        - text
+        - multitext
+        - select
+        - multiselect
+        - boolean
+        - date
+        - datetime
+        - number
+        - link
+      type: string
+    FieldsResponse:
+      description: |
+        The `fields` will contain all of the custom metadata fields as well as the system fields,
+        in order.
+      properties:
+        fields:
+          items:
+            $ref: '#/components/schemas/FieldSpec'
+          type: array
+      required:
+        - fields
+      type: object
+    GeneralError:
+      properties:
+        message:
+          type: string
+        type:
+          $ref: '#/components/schemas/GeneralErrorType'
+      required:
+        - type
+        - message
+      type: object
+    GeneralErrorResponse:
+      description: General error response that usually has a very generic message
+      properties:
+        errors:
+          items:
+            $ref: '#/components/schemas/GeneralError'
+          type: array
+      required:
+        - errors
+      type: object
+    GeneralErrorType:
+      description: The type of the general error response
+      enum:
+        - GeneralError
+      type: string
+    PageInfo:
+      description: Contains the pagination metadata for a response
+      properties:
+        current:
+          description: The current page number using 1-based array indexing
+          type: integer
+        itemCount:
+          description: Total number of items
+          type: integer
+        itemsPerPage:
+          description: |
+            Maximum items that can be on the page. They may be different from
+            the requested number of times
+          type: integer
+        unfilteredItemCount:
+          description: Item count if filters were not applied
+          type: integer
+      required:
+        - itemCount
+        - itemsPerPage
+        - unfilteredItemCount
+        - current
+      type: object
+    PagedCustomFieldResponse:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/FieldSpec'
+          type: array
+        page:
+          $ref: '#/components/schemas/PageInfo'
+      required:
+        - page
+        - data
+      type: object
+    ResourceKind:
+      description: A list of supported resource kinds
+      enum:
+        - datasource
+        - table
+        - column
+        - usecase
+        - bireport
+        - glossaryitem
+        - application
+        - pipeline
+        - api
+        - model
+        - stream
+        - filestorage
+      type: string
+    SearchCategory:
+      description: A value that describes which resource kinds (`ResourceKind`) to include in the search response.
+      enum:
+        - data
+        - bi
+        - usecase
+        - glossary
+        - application
+        - pipeline
+        - api
+        - model
+        - stream
+        - filestorage
+      type: string
+    UpdateCustomFieldRequest:
+      properties:
+        description:
+          description: |
+            A description of the purpose of this field
+          maxLength: 255
+          nullable: true
+          type: string
+        displayName:
+          description: |
+            A nice human-readable name for that field
+          nullable: true
+          type: string
+        filterable:
+          description: |
+            Should this field show up as a filter in the catalog
+          nullable: true
+          type: boolean
+        hideIfEmpty:
+          description: |
+            Should this field be hidden when its value is empty
+          nullable: true
+          type: boolean
+        maxValue:
+          nullable: true
+          type: number
+        minValue:
+          nullable: true
+          type: number
+        searchable:
+          description: |
+            Should this field be used in the catalog fuzzy search
+          nullable: true
+          type: boolean
+        validValues:
+          items:
+            type: string
+          nullable: true
+          type: array
+      type: object
+    UpdateFieldSetRequest:
+      properties:
+        fields:
+          items:
+            description: A list of custom field names in display order
+            type: string
+          type: array
+      required:
+        - fields
+      type: object
+    UpdateFieldsRequest:
+      description: |
+        The `fields` array should contain all of the fields in the desired order.
+
+        Additionally, we require all field specifications _must_ contain the following fields:
+
+          *   `category`
+      properties:
+        fields:
+          items:
+            $ref: '#/components/schemas/FieldSpecUpdateRequest'
+          type: array
+      required:
+        - fields
+      type: object
+  securitySchemes:
+    doubleCookieAuth:
+      description: Cookie value set during login, automatically sent by the browser
+      in: header
+      name: double-cookie
+      type: apiKey
+    doubleCookieHeader:
+      in: header
+      name: X-Double-Cookie
+      type: apiKey
+    tokenAuth:
+      bearerFormat: Personal Access Token or Service Account Token
+      scheme: bearer
+      type: http
+paths:
+  /api/v1/{projectId}/fields/{entityClassId}:
+    get:
+      description: |
+        This returns the fields spec for the specified entity type.
+      operationId: GetFields
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FieldsResponse'
+          description: Here are the fields
+      summary: Get Current Fields Spec
+      tags:
+        - fields
+      x-handler-group: Fields
+    parameters:
+      - description: UUID of the project
+        in: path
+        name: projectId
+        required: true
+        schema:
+          format: uuid
+          type: string
+      - description: Identifier of the entity class
+        in: path
+        name: entityClassId
+        required: true
+        schema:
+          $ref: '#/components/schemas/ResourceKind'
+    put:
+      description: |
+        This updates the fields spec used to validate catalog entries
+      operationId: UpdateFields
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateFieldsRequest'
+        description: The fields spec to set
+        required: true
+      responses:
+        "204":
+          description: Successfully updated the schema
+      summary: Update the current field spec
+      tags:
+        - fields
+      x-handler-group: Fields
+  /api/v2/{projectId}/field-sets:
+    get:
+      description: |
+        This returns the merged field-set for a list of resource kinds
+      operationId: GetMergedFieldSets
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FieldsResponse'
+          description: Here are the fields
+      summary: Get combined/merged fields-set
+      tags:
+        - fields
+      x-handler-group: FieldsV2
+    parameters:
+      - description: UUID of the project
+        in: path
+        name: projectId
+        required: true
+        schema:
+          format: uuid
+          type: string
+      - description: The category is a predefined collection of `kinds` that are used to filter search results, must be set if `kinds` is omitted or empty
+        in: query
+        name: category
+        required: false
+        schema:
+          $ref: '#/components/schemas/SearchCategory'
+      - description: A specific list of Resource kinds. Must be set if `category` is empty or omitted.
+        explode: false
+        in: query
+        name: kinds
+        required: false
+        schema:
+          items:
+            $ref: '#/components/schemas/ResourceKind'
+          type: array
+        style: form
+  /api/v2/{projectId}/field-sets/{resourceKind}:
+    get:
+      description: |
+        This returns the fields spec for the specified entity type.
+      operationId: GetFieldSet
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FieldsResponse'
+          description: Here are the fields
+      summary: Get Current Fields Spec
+      tags:
+        - fields
+      x-handler-group: FieldsV2
+    parameters:
+      - description: UUID of the project
+        in: path
+        name: projectId
+        required: true
+        schema:
+          format: uuid
+          type: string
+      - description: Identifier of the entity class
+        in: path
+        name: resourceKind
+        required: true
+        schema:
+          $ref: '#/components/schemas/ResourceKind'
+    put:
+      description: |
+        This updates the fields spec used to validate catalog entries, use this to assign or unassign
+        custom fields to the FieldSet. You can also use this to reoder the custom fields.
+      operationId: UpdateFieldSet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateFieldSetRequest'
+        description: The fields spec to set
+        required: true
+      responses:
+        "204":
+          description: Successfully updated the schema
+      summary: Update the current field spec assignments or order
+      tags:
+        - fields
+      x-handler-group: FieldsV2
+  /api/v2/{projectId}/fields:
+    get:
+      operationId: ListCustomFields
+      parameters:
+        - description: Search fields by name and description
+          in: query
+          name: search
+          schema:
+            type: string
+        - description: Filter the response to only those unassigned for the named kind
+          in: query
+          name: unassigned
+          schema:
+            $ref: '#/components/schemas/ResourceKind'
+        - description: The current set of paged results to display, based on a 1-based array index
+          in: query
+          name: page
+          required: false
+          schema:
+            type: integer
+        - description: Maximum items to return in the response per page
+          in: query
+          name: pageSize
+          required: false
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 5
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedCustomFieldResponse'
+          description: Here are the fields
+      summary: List the available custom Fields
+      tags:
+        - fields
+      x-handler-group: FieldsV2
+    parameters:
+      - description: UUID of the project
+        in: path
+        name: projectId
+        required: true
+        schema:
+          format: uuid
+          type: string
+    post:
+      operationId: CreateCustomField
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCustomFieldRequest'
+        description: The fields spec to set
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FieldSpec'
+          description: Successfully create the Field
+      summary: Create new custom Field
+      tags:
+        - fields
+      x-handler-group: FieldsV2
+  /api/v2/{projectId}/fields/{fieldName}:
+    delete:
+      operationId: DeleteCustomField
+      responses:
+        "204":
+          description: Field successfully deleted
+      summary: Delete a field
+      tags:
+        - fields
+      x-handler-group: FieldsV2
+    parameters:
+      - description: UUID of the project
+        in: path
+        name: projectId
+        required: true
+        schema:
+          format: uuid
+          type: string
+      - description: Name of the field
+        in: path
+        name: fieldName
+        required: true
+        schema:
+          type: string
+    patch:
+      operationId: UpdateCustomField
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCustomFieldRequest'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FieldSpec'
+          description: Field successfully updated
+      summary: Update a field
+      tags:
+        - fields
+      x-handler-group: FieldsV2
+
+security:
+  - tokenAuth: []
+servers:
+  - description: Locally running
+    url: http://localhost:{port}
+    variables:
+      port:
+        default: "9191"
+  - description: Production environment
+    url: https://cloud.example.com/{tenantId}
+    variables:
+      tenantId:
+        default: demo
+tags:
+  - description: Endpoints for managing the catalog structure
+    name: fields


### PR DESCRIPTION
The `components.responses` is an optional section of the API spec. This
fix allows us to filter  API specs that omit this section.

## Ticket
<!-- Paste the url for the jira task/bug or Github issue here -->
NA

## How Has This Been Verified?
<!--- Please describe in detail how you tested your changes. -->
New unit test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [ ] New code can be debugged via logs.
- [x] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
