### PR TITLE
feat: Add From* methods to set oneOf data models

### DIFF
--- a/pkg/generators/models/templates.go
+++ b/pkg/generators/models/templates.go
@@ -188,6 +188,15 @@ func (m *{{$modelName}}) UnmarshalJSON(bs []byte) error {
 	return json.Unmarshal(bs, &m.data)
 }
 
+
+{{- range $convert := .ConvertSpecs }}
+// From{{firstUpper $convert.TargetGoType}} sets the {{$modelName}} data.
+func (m *{{$modelName}}) From{{firstUpper $convert.TargetGoType}}(data {{$convert.TargetGoType}}) {
+	m.data = data
+}
+
+{{- end }}
+
 // As converts {{$modelName}} to a user defined structure.
 func (m {{$modelName}}) As(target interface{}) error {
 	return mapstructure.Decode(m.data, target)

--- a/pkg/generators/models/testdata/cases/oneof/expected/model_bar.go
+++ b/pkg/generators/models/testdata/cases/oneof/expected/model_bar.go
@@ -25,6 +25,16 @@ func (m *Bar) UnmarshalJSON(bs []byte) error {
 	return json.Unmarshal(bs, &m.data)
 }
 
+// FromString sets the Bar data.
+func (m *Bar) FromString(data string) {
+	m.data = data
+}
+
+// FromInt32 sets the Bar data.
+func (m *Bar) FromInt32(data int32) {
+	m.data = data
+}
+
 // As converts Bar to a user defined structure.
 func (m Bar) As(target interface{}) error {
 	return mapstructure.Decode(m.data, target)

--- a/pkg/generators/models/testdata/cases/oneof/expected/model_baz.go
+++ b/pkg/generators/models/testdata/cases/oneof/expected/model_baz.go
@@ -25,6 +25,21 @@ func (m *Baz) UnmarshalJSON(bs []byte) error {
 	return json.Unmarshal(bs, &m.data)
 }
 
+// FromFoo sets the Baz data.
+func (m *Baz) FromFoo(data Foo) {
+	m.data = data
+}
+
+// FromBar sets the Baz data.
+func (m *Baz) FromBar(data Bar) {
+	m.data = data
+}
+
+// FromPerson sets the Baz data.
+func (m *Baz) FromPerson(data Person) {
+	m.data = data
+}
+
 // As converts Baz to a user defined structure.
 func (m Baz) As(target interface{}) error {
 	return mapstructure.Decode(m.data, target)

--- a/pkg/generators/models/testdata/cases/oneof/generated/model_bar.go
+++ b/pkg/generators/models/testdata/cases/oneof/generated/model_bar.go
@@ -25,6 +25,16 @@ func (m *Bar) UnmarshalJSON(bs []byte) error {
 	return json.Unmarshal(bs, &m.data)
 }
 
+// FromString sets the Bar data.
+func (m *Bar) FromString(data string) {
+	m.data = data
+}
+
+// FromInt32 sets the Bar data.
+func (m *Bar) FromInt32(data int32) {
+	m.data = data
+}
+
 // As converts Bar to a user defined structure.
 func (m Bar) As(target interface{}) error {
 	return mapstructure.Decode(m.data, target)

--- a/pkg/generators/models/testdata/cases/oneof/generated/model_baz.go
+++ b/pkg/generators/models/testdata/cases/oneof/generated/model_baz.go
@@ -25,6 +25,21 @@ func (m *Baz) UnmarshalJSON(bs []byte) error {
 	return json.Unmarshal(bs, &m.data)
 }
 
+// FromFoo sets the Baz data.
+func (m *Baz) FromFoo(data Foo) {
+	m.data = data
+}
+
+// FromBar sets the Baz data.
+func (m *Baz) FromBar(data Bar) {
+	m.data = data
+}
+
+// FromPerson sets the Baz data.
+func (m *Baz) FromPerson(data Person) {
+	m.data = data
+}
+
 // As converts Baz to a user defined structure.
 func (m Baz) As(target interface{}) error {
 	return mapstructure.Decode(m.data, target)


### PR DESCRIPTION
Extend the template for `oneOf` so that each possible sub-type has a
corresponding `From*` method that allows the caller to safely set the
data for the oneOf model.

## How Has This Been Verified?
<!--- Please describe in detail how you tested your changes. -->
Updated unit tests and experimenting with it in a Hub feature branch

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [ ] New code can be debugged via logs.
- [x] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
