### PR TITLE
add a Set(data interface{}) function to oneof models

### DIFF
--- a/pkg/generators/models/templates.go
+++ b/pkg/generators/models/templates.go
@@ -188,6 +188,10 @@ func (m *{{$modelName}}) UnmarshalJSON(bs []byte) error {
 	return json.Unmarshal(bs, &m.data)
 }
 
+// Set sets the {{$modelName}} data.
+func (m *{{$modelName}}) Set(data interface{}) {
+	m.data = data
+}
 
 {{- range $convert := .ConvertSpecs }}
 // From{{firstUpper $convert.TargetGoType}} sets the {{$modelName}} data.

--- a/pkg/generators/models/testdata/cases/oneof/expected/model_bar.go
+++ b/pkg/generators/models/testdata/cases/oneof/expected/model_bar.go
@@ -25,6 +25,11 @@ func (m *Bar) UnmarshalJSON(bs []byte) error {
 	return json.Unmarshal(bs, &m.data)
 }
 
+// Set sets the Bar data.
+func (m *Bar) Set(data interface{}) {
+	m.data = data
+}
+
 // FromString sets the Bar data.
 func (m *Bar) FromString(data string) {
 	m.data = data

--- a/pkg/generators/models/testdata/cases/oneof/expected/model_baz.go
+++ b/pkg/generators/models/testdata/cases/oneof/expected/model_baz.go
@@ -25,6 +25,11 @@ func (m *Baz) UnmarshalJSON(bs []byte) error {
 	return json.Unmarshal(bs, &m.data)
 }
 
+// Set sets the Baz data.
+func (m *Baz) Set(data interface{}) {
+	m.data = data
+}
+
 // FromFoo sets the Baz data.
 func (m *Baz) FromFoo(data Foo) {
 	m.data = data

--- a/pkg/generators/models/testdata/cases/oneof/generated/model_bar.go
+++ b/pkg/generators/models/testdata/cases/oneof/generated/model_bar.go
@@ -25,6 +25,11 @@ func (m *Bar) UnmarshalJSON(bs []byte) error {
 	return json.Unmarshal(bs, &m.data)
 }
 
+// Set sets the Bar data.
+func (m *Bar) Set(data interface{}) {
+	m.data = data
+}
+
 // FromString sets the Bar data.
 func (m *Bar) FromString(data string) {
 	m.data = data

--- a/pkg/generators/models/testdata/cases/oneof/generated/model_baz.go
+++ b/pkg/generators/models/testdata/cases/oneof/generated/model_baz.go
@@ -25,6 +25,11 @@ func (m *Baz) UnmarshalJSON(bs []byte) error {
 	return json.Unmarshal(bs, &m.data)
 }
 
+// Set sets the Baz data.
+func (m *Baz) Set(data interface{}) {
+	m.data = data
+}
+
 // FromFoo sets the Baz data.
 func (m *Baz) FromFoo(data Foo) {
 	m.data = data


### PR DESCRIPTION
This is needed to control the content of the oneof data for low level interactions.

<!-- Summary of changes above here -->

## Ticket
<!-- Paste the url for the jira task/bug or Github issue here -->

## How Has This Been Verified?
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The change works as expected.
- [ ] New code can be debugged via logs.
- [ ] I have added tests to cover my changes.
- [ ] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
