### PR TITLE
fix: MarshalJSON should not have pointer reciever

### DIFF
--- a/pkg/generators/models/templates.go
+++ b/pkg/generators/models/templates.go
@@ -179,7 +179,7 @@ type {{.Name}} struct {
 {{- $modelName := .Name }}
 
 // MarshalJSON implementes the json.Marshaller interface
-func (m *{{$modelName}}) MarshalJSON() ([]byte, error) {
+func (m {{$modelName}}) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.data)
 }
 

--- a/pkg/generators/models/testdata/cases/oneof/expected/model_bar.go
+++ b/pkg/generators/models/testdata/cases/oneof/expected/model_bar.go
@@ -16,7 +16,7 @@ type Bar struct {
 }
 
 // MarshalJSON implementes the json.Marshaller interface
-func (m *Bar) MarshalJSON() ([]byte, error) {
+func (m Bar) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.data)
 }
 

--- a/pkg/generators/models/testdata/cases/oneof/expected/model_baz.go
+++ b/pkg/generators/models/testdata/cases/oneof/expected/model_baz.go
@@ -16,7 +16,7 @@ type Baz struct {
 }
 
 // MarshalJSON implementes the json.Marshaller interface
-func (m *Baz) MarshalJSON() ([]byte, error) {
+func (m Baz) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.data)
 }
 

--- a/pkg/generators/models/testdata/cases/oneof/generated/model_bar.go
+++ b/pkg/generators/models/testdata/cases/oneof/generated/model_bar.go
@@ -16,7 +16,7 @@ type Bar struct {
 }
 
 // MarshalJSON implementes the json.Marshaller interface
-func (m *Bar) MarshalJSON() ([]byte, error) {
+func (m Bar) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.data)
 }
 

--- a/pkg/generators/models/testdata/cases/oneof/generated/model_baz.go
+++ b/pkg/generators/models/testdata/cases/oneof/generated/model_baz.go
@@ -16,7 +16,7 @@ type Baz struct {
 }
 
 // MarshalJSON implementes the json.Marshaller interface
-func (m *Baz) MarshalJSON() ([]byte, error) {
+func (m Baz) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.data)
 }
 


### PR DESCRIPTION
The MarshalJSON interface needs to be implemented on a value
reciever. When it is a pointer receiver, then you can _only_ marshal
pointers of the type.  Values of the type will just marshal to an empty
json object. This makes the types much harder or impossible to use.

## How Has This Been Verified?
<!--- Please describe in detail how you tested your changes. -->
Tested in Hub to fix a failing validation test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [ ] New code can be debugged via logs.
- [x] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
