### PR TITLE
expose the merge package as command

### DIFF
--- a/cmd/openapi-generator-go/cmd/merge.go
+++ b/cmd/openapi-generator-go/cmd/merge.go
@@ -47,9 +47,9 @@ var mergeCmd = &cobra.Command{
 			log.Fatal().Err(err).Msg("can't read dir flag")
 		}
 
-		destinationFile, err := cmd.Flags().GetString("spec")
+		destinationFile, err := cmd.Flags().GetString("merged-spec")
 		if err != nil {
-			log.Fatal().Err(err).Msg("can't read spec flag")
+			log.Fatal().Err(err).Msg("can't read merged-spec flag")
 		}
 
 		f, err := os.Open(baseFile)
@@ -79,4 +79,5 @@ func init() {
 
 	mergeCmd.Flags().StringP("base", "b", "base.yaml", "base spec")
 	mergeCmd.Flags().StringP("dir", "d", "./parts", "part directory")
+	mergeCmd.Flags().StringP("merged-spec", "m", "api.yaml", "output spec file")
 }

--- a/cmd/openapi-generator-go/cmd/merge.go
+++ b/cmd/openapi-generator-go/cmd/merge.go
@@ -1,0 +1,82 @@
+/*
+Copyright © 2021 Contiamo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/contiamo/openapi-generator-go/pkg/merge"
+)
+
+// mergeCmd merges a directory of openapi specs into a base spec.
+var mergeCmd = &cobra.Command{
+	Use:   "merge",
+	Short: "merges a directory of openapi specs into a base spec",
+	Run: func(cmd *cobra.Command, args []string) {
+		baseFile, err := cmd.Flags().GetString("base")
+		if err != nil {
+			log.Fatal().Err(err).Msg("can't read base flag")
+		}
+
+		dir, err := cmd.Flags().GetString("dir")
+		if err != nil {
+			log.Fatal().Err(err).Msg("can't read dir flag")
+		}
+
+		destinationFile, err := cmd.Flags().GetString("output")
+		if err != nil {
+			log.Fatal().Err(err).Msg("can't read output flag")
+		}
+
+		f, err := os.Open(baseFile)
+		if err != nil {
+			log.Fatal().Err(err).Msg("can't read base spec")
+		}
+
+		mergedSpec, err := merge.OpenAPI(f, dir)
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to merge the api spec")
+		}
+
+		bs, err := yaml.Marshal(mergedSpec)
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to encode spec")
+		}
+
+		err = ioutil.WriteFile(destinationFile, bs, 0644)
+		if err != nil {
+			log.Fatal().Str("output", destinationFile).Err(err).Msg("failed to create output file")
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(mergeCmd)
+
+	mergeCmd.Flags().StringP("base", "b", "base.yaml", "base spec")
+	mergeCmd.Flags().StringP("dir", "d", "./parts", "part directory")
+}

--- a/cmd/openapi-generator-go/cmd/merge.go
+++ b/cmd/openapi-generator-go/cmd/merge.go
@@ -47,9 +47,9 @@ var mergeCmd = &cobra.Command{
 			log.Fatal().Err(err).Msg("can't read dir flag")
 		}
 
-		destinationFile, err := cmd.Flags().GetString("output")
+		destinationFile, err := cmd.Flags().GetString("spec")
 		if err != nil {
-			log.Fatal().Err(err).Msg("can't read output flag")
+			log.Fatal().Err(err).Msg("can't read spec flag")
 		}
 
 		f, err := os.Open(baseFile)

--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -303,16 +303,16 @@ func deepMerge(left *openapi3.SchemaRef, right *openapi3.SchemaRef, passed passe
 	}
 
 	// merge docs
-	if right.Value.Title != "" {
+	if right.Value.Title != "" && out.Value.Title == "" {
 		out.Value.Title = right.Value.Title
 	}
-	if right.Value.Description != "" {
+	if right.Value.Description != "" && out.Value.Description == "" {
 		out.Value.Description = right.Value.Description
 	}
-	if right.Value.ExternalDocs != nil {
+	if right.Value.ExternalDocs != nil && out.Value.ExternalDocs == nil {
 		out.Value.ExternalDocs = right.Value.ExternalDocs
 	}
-	if right.Value.Example != nil {
+	if right.Value.Example != nil && out.Value.Example == nil {
 		out.Value.Example = right.Value.Example
 	}
 


### PR DESCRIPTION
This adds the `merge` subcommand to the generator, so that it now contains all functionality needed for all our openapi needs.
That way we can remove the generate.go cmd from hub for example which will remove the dependency on idp for updating the models within hub. 

The command will be used like this:
```
openapi-generator-go merge --base openapi/base.yaml --dir openapi/parts --spec api.yaml
```

## Ticket
<!-- Paste the url for the jira task/bug or Github issue here -->

## How Has This Been Verified?
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [x] New code can be debugged via logs.
- [ ] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
