### PR TITLE
ci: Add workflow to enforce conventional commit titles

### DIFF
--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,0 +1,21 @@
+name: 'Conventional commit titles'
+on:
+  pull_request:
+    types:
+      # Check title when opened.
+      - opened
+      # Check title when new commits are pushed.
+      # Required to use as a status check.
+      - synchronize
+      # When the title or description change
+      - edited
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: deepakputhraya/action-pr-title@master
+        with:
+          # Ensure pull request titles match the Conventional Commits specification https://www.conventionalcommits.org/en/v1.0.0/
+          regex: '^(feat|fix|chore|ci|refactor|test)!?:'


### PR DESCRIPTION
The workflow will enforce that all PR titles start with the conventional commit prefix


## Ticket
<!-- Paste the url for the jira task/bug or Github issue here -->
NA 

## How Has This Been Verified?
<!--- Please describe in detail how you tested your changes. -->
WIP, this PR will verify itself

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [ ] New code can be debugged via logs.
- [ ] I have added tests to cover my changes.
- [ ] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
