### PR TITLE
feat: improve description handling in allOfs

### DIFF
--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -252,7 +252,7 @@ func resolveAllOf(ref *openapi3.SchemaRef, passed passedSchemas) (out *openapi3.
 	// this is used for the special edge cases like this
 	//   allOf:
 	//      - description: "this will only set the description value"
-	// 		- $ref: '#/components/schemas/ColumnTypeMetadata'
+	// 	- $ref: '#/components/schemas/ColumnTypeMetadata'
 	//
 	// without this method, the allOf will generate an inline type, but the resulting code
 	// is much better and easier to use if we drop the first allOf item and just treat it like

--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -249,6 +249,16 @@ func resolveAllOf(ref *openapi3.SchemaRef, passed passedSchemas) (out *openapi3.
 		return out
 	}
 
+	// this is used for the special edge cases like this
+	//   allOf:
+	//      - description: "this will only set the description value"
+	// 		- $ref: '#/components/schemas/ColumnTypeMetadata'
+	//
+	// without this method, the allOf will generate an inline type, but the resulting code
+	// is much better and easier to use if we drop the first allOf item and just treat it like
+	// the special case of a single `ref`, which will used the named `ColumnTypeMetadata` type.
+	ref.Value.AllOf = removeSemanticallyEmptyRefs(ref.Value.AllOf)
+
 	isSelfRef := false
 	for _, subSchema := range ref.Value.AllOf {
 		if _, exists := passed[subSchema]; exists {
@@ -273,6 +283,92 @@ func resolveAllOf(ref *openapi3.SchemaRef, passed passedSchemas) (out *openapi3.
 	}
 
 	return out
+}
+
+// removeSemanticallyEmptyRefs removes SchemaRefs from an allOf list  that will not produce any
+// meaningful changes to the generated type. Specifically this will remove things like
+//
+//   allOf:
+//      - description: "this will only set the description value"
+func removeSemanticallyEmptyRefs(allOf []*openapi3.SchemaRef) []*openapi3.SchemaRef {
+	if allOf == nil {
+		return allOf
+	}
+
+	refCount := 0
+	for _, subRef := range allOf {
+		if subRef.Ref != "" {
+			refCount++
+		}
+	}
+
+	// nothing we can do here, there are multiple references, so any
+	// difficult mixins can be handled by the deepMerge
+	if refCount != 1 {
+		return allOf
+	}
+
+	reduced := []*openapi3.SchemaRef{}
+	for _, subRef := range allOf {
+		if isNonEmptySchemaRef(subRef) {
+			reduced = append(reduced, subRef)
+		}
+	}
+
+	return reduced
+}
+
+// isNonEmptySchemaRef tests if the given SchemaRef has a non-trivial
+// definition. This means that at least one of its properties has an impact
+// on the resulting type or validation of the generated model. Changes
+// to the description, title, etc, are considered "trivial" changes that
+// we can choose to ignore.
+func isNonEmptySchemaRef(ref *openapi3.SchemaRef) bool {
+	if ref == nil {
+		return false
+	}
+
+	// it refers to another schema
+	if ref.Ref != "" {
+		return true
+	}
+
+	// has empty ref _and_ empty value
+	if ref.Value == nil {
+		return false
+	}
+
+	val := ref.Value
+	switch {
+	case
+		// schema properties
+		val.Nullable, val.ReadOnly, val.WriteOnly,
+		val.Format != "",
+		val.Default != nil,
+		val.Type != "",
+		// string related
+		val.MinLength != 0,
+		val.MaxLength != nil,
+		val.Pattern != "",
+		// number related
+		val.Min != nil,
+		val.Max != nil,
+		val.MultipleOf != nil,
+		// array related
+		val.Items != nil,
+		val.MinItems != 0,
+		val.MaxItems != nil,
+		// object related
+		val.MinProps != 0,
+		val.MaxProps != nil,
+		// array values properties
+		len(val.Required) != 0,
+		len(val.Properties) != 0, len(val.Enum) != 0,
+		len(val.AllOf) != 0, len(val.AnyOf) != 0:
+		return true
+	default:
+		return false
+	}
 }
 
 // deepMerge merges `right` into `left` schema recursively resolving types (e.g. `allOf`).

--- a/pkg/generators/models/models_test.go
+++ b/pkg/generators/models/models_test.go
@@ -68,6 +68,10 @@ func TestModels(t *testing.T) {
 			directory: "testdata/cases/allof5",
 		},
 		{
+			name:      "allOf can skip certain mixins",
+			directory: "testdata/cases/allof_mixin_skipping",
+		},
+		{
 			name:      "typed arrays generated typed arrays in go",
 			directory: "testdata/cases/typed_arrays",
 		},

--- a/pkg/generators/models/testdata/cases/allof_mixin_skipping/api.yaml
+++ b/pkg/generators/models/testdata/cases/allof_mixin_skipping/api.yaml
@@ -1,0 +1,81 @@
+openapi: 3.0.0
+info:
+  version: 0.1.0
+  title: Test
+
+components:
+  schemas:
+    ColumnMetadata:
+      description: Metadata for single column
+      properties:
+        comment:
+          description: Column description
+          type: string
+        name:
+          description: Column name
+          type: string
+        type:
+          allOf:
+          - $ref: '#/components/schemas/ColumnTypeMetadata'
+          - description: Column type
+      required:
+      - name
+      - type
+      type: object
+
+    ColumnTypeMetadata:
+      description: Type metadata
+      properties:
+        columns:
+          description: List of columns if this type is structural
+          items:
+            $ref: '#/components/schemas/ColumnMetadata'
+          type: array
+        itemType:
+          allOf:
+          - $ref: '#/components/schemas/ColumnTypeMetadata'
+          - description: Array item type if this type is array
+            nullable: true
+        nullable:
+          $ref: '#/components/schemas/Nullability'
+        originalName:
+          description: Original column type as given by data source
+          type: string
+        type:
+          allOf:
+          - $ref: '#/components/schemas/ColumnType'
+          - description: Column type
+      required:
+      - nullable
+      - originalName
+      - type
+      type: object
+
+    ColumnType:
+      default: other
+      description: Normalized column type. If type cannot be determined or is not
+        compatible, then 'other'.
+      enum:
+      - varchar array
+      - boolean
+      - date
+      - numeric
+      - double precision
+      - float
+      - integer
+      - bigint
+      - other
+      - smallint
+      - varchar
+      - time
+      - timestamp
+      type: string
+
+    Nullability:
+      default: NullableUnknown
+      description: Column nullability
+      enum:
+      - NoNulls
+      - Nullable
+      - NullableUnknown
+      type: string

--- a/pkg/generators/models/testdata/cases/allof_mixin_skipping/expected/model_column_metadata.go
+++ b/pkg/generators/models/testdata/cases/allof_mixin_skipping/expected/model_column_metadata.go
@@ -1,0 +1,59 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// ColumnMetadata is an object. Metadata for single column
+type ColumnMetadata struct {
+	// Comment: Column description
+	Comment string `json:"comment,omitempty"`
+	// Name: Column name
+	Name string `json:"name"`
+	// Type: Type metadata
+	Type ColumnTypeMetadata `json:"type"`
+}
+
+// Validate implements basic validation for this model
+func (m ColumnMetadata) Validate() error {
+	return validation.Errors{
+		"type": validation.Validate(
+			m.Type, validation.NotNil,
+		),
+	}.Filter()
+}
+
+// GetComment returns the Comment property
+func (m ColumnMetadata) GetComment() string {
+	return m.Comment
+}
+
+// SetComment sets the Comment property
+func (m *ColumnMetadata) SetComment(val string) {
+	m.Comment = val
+}
+
+// GetName returns the Name property
+func (m ColumnMetadata) GetName() string {
+	return m.Name
+}
+
+// SetName sets the Name property
+func (m *ColumnMetadata) SetName(val string) {
+	m.Name = val
+}
+
+// GetType returns the Type property
+func (m ColumnMetadata) GetType() ColumnTypeMetadata {
+	return m.Type
+}
+
+// SetType sets the Type property
+func (m *ColumnMetadata) SetType(val ColumnTypeMetadata) {
+	m.Type = val
+}

--- a/pkg/generators/models/testdata/cases/allof_mixin_skipping/expected/model_column_type.go
+++ b/pkg/generators/models/testdata/cases/allof_mixin_skipping/expected/model_column_type.go
@@ -1,0 +1,84 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// ColumnType is an enum. Normalized column type. If type cannot be determined or is not compatible, then 'other'.
+type ColumnType string
+
+// Validate implements basic validation for this model
+func (m ColumnType) Validate() error {
+	return InKnownColumnType.Validate(m)
+}
+
+var (
+	ColumnTypeBigint          ColumnType = "bigint"
+	ColumnTypeBoolean         ColumnType = "boolean"
+	ColumnTypeDate            ColumnType = "date"
+	ColumnTypeDoublePrecision ColumnType = "double precision"
+	ColumnTypeFloat           ColumnType = "float"
+	ColumnTypeInteger         ColumnType = "integer"
+	ColumnTypeNumeric         ColumnType = "numeric"
+	ColumnTypeOther           ColumnType = "other"
+	ColumnTypeSmallint        ColumnType = "smallint"
+	ColumnTypeTime            ColumnType = "time"
+	ColumnTypeTimestamp       ColumnType = "timestamp"
+	ColumnTypeVarchar         ColumnType = "varchar"
+	ColumnTypeVarcharArray    ColumnType = "varchar array"
+
+	// KnownColumnType is the list of valid ColumnType
+	KnownColumnType = []ColumnType{
+		ColumnTypeBigint,
+		ColumnTypeBoolean,
+		ColumnTypeDate,
+		ColumnTypeDoublePrecision,
+		ColumnTypeFloat,
+		ColumnTypeInteger,
+		ColumnTypeNumeric,
+		ColumnTypeOther,
+		ColumnTypeSmallint,
+		ColumnTypeTime,
+		ColumnTypeTimestamp,
+		ColumnTypeVarchar,
+		ColumnTypeVarcharArray,
+	}
+	// KnownColumnTypeString is the list of valid ColumnType as string
+	KnownColumnTypeString = []string{
+		string(ColumnTypeBigint),
+		string(ColumnTypeBoolean),
+		string(ColumnTypeDate),
+		string(ColumnTypeDoublePrecision),
+		string(ColumnTypeFloat),
+		string(ColumnTypeInteger),
+		string(ColumnTypeNumeric),
+		string(ColumnTypeOther),
+		string(ColumnTypeSmallint),
+		string(ColumnTypeTime),
+		string(ColumnTypeTimestamp),
+		string(ColumnTypeVarchar),
+		string(ColumnTypeVarcharArray),
+	}
+
+	// InKnownColumnType is an ozzo-validator for ColumnType
+	InKnownColumnType = validation.In(
+		ColumnTypeBigint,
+		ColumnTypeBoolean,
+		ColumnTypeDate,
+		ColumnTypeDoublePrecision,
+		ColumnTypeFloat,
+		ColumnTypeInteger,
+		ColumnTypeNumeric,
+		ColumnTypeOther,
+		ColumnTypeSmallint,
+		ColumnTypeTime,
+		ColumnTypeTimestamp,
+		ColumnTypeVarchar,
+		ColumnTypeVarcharArray,
+	)
+)

--- a/pkg/generators/models/testdata/cases/allof_mixin_skipping/expected/model_column_type_metadata.go
+++ b/pkg/generators/models/testdata/cases/allof_mixin_skipping/expected/model_column_type_metadata.go
@@ -1,0 +1,92 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// ColumnTypeMetadata is an object. Type metadata
+type ColumnTypeMetadata struct {
+	// Columns: List of columns if this type is structural
+	Columns []ColumnMetadata `json:"columns,omitempty"`
+	// ItemType: Type metadata
+	ItemType *ColumnTypeMetadata `json:"itemType,omitempty"`
+	// Nullable: Column nullability
+	Nullable Nullability `json:"nullable"`
+	// OriginalName: Original column type as given by data source
+	OriginalName string `json:"originalName"`
+	// Type: Normalized column type. If type cannot be determined or is not compatible, then 'other'.
+	Type ColumnType `json:"type"`
+}
+
+// Validate implements basic validation for this model
+func (m ColumnTypeMetadata) Validate() error {
+	return validation.Errors{
+		"columns": validation.Validate(
+			m.Columns,
+		),
+		"itemType": validation.Validate(
+			m.ItemType,
+		),
+		"nullable": validation.Validate(
+			m.Nullable, validation.Required,
+		),
+		"type": validation.Validate(
+			m.Type, validation.Required,
+		),
+	}.Filter()
+}
+
+// GetColumns returns the Columns property
+func (m ColumnTypeMetadata) GetColumns() []ColumnMetadata {
+	return m.Columns
+}
+
+// SetColumns sets the Columns property
+func (m *ColumnTypeMetadata) SetColumns(val []ColumnMetadata) {
+	m.Columns = val
+}
+
+// GetItemType returns the ItemType property
+func (m ColumnTypeMetadata) GetItemType() *ColumnTypeMetadata {
+	return m.ItemType
+}
+
+// SetItemType sets the ItemType property
+func (m *ColumnTypeMetadata) SetItemType(val *ColumnTypeMetadata) {
+	m.ItemType = val
+}
+
+// GetNullable returns the Nullable property
+func (m ColumnTypeMetadata) GetNullable() Nullability {
+	return m.Nullable
+}
+
+// SetNullable sets the Nullable property
+func (m *ColumnTypeMetadata) SetNullable(val Nullability) {
+	m.Nullable = val
+}
+
+// GetOriginalName returns the OriginalName property
+func (m ColumnTypeMetadata) GetOriginalName() string {
+	return m.OriginalName
+}
+
+// SetOriginalName sets the OriginalName property
+func (m *ColumnTypeMetadata) SetOriginalName(val string) {
+	m.OriginalName = val
+}
+
+// GetType returns the Type property
+func (m ColumnTypeMetadata) GetType() ColumnType {
+	return m.Type
+}
+
+// SetType sets the Type property
+func (m *ColumnTypeMetadata) SetType(val ColumnType) {
+	m.Type = val
+}

--- a/pkg/generators/models/testdata/cases/allof_mixin_skipping/expected/model_nullability.go
+++ b/pkg/generators/models/testdata/cases/allof_mixin_skipping/expected/model_nullability.go
@@ -1,0 +1,44 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Nullability is an enum. Column nullability
+type Nullability string
+
+// Validate implements basic validation for this model
+func (m Nullability) Validate() error {
+	return InKnownNullability.Validate(m)
+}
+
+var (
+	NullabilityNoNulls         Nullability = "NoNulls"
+	NullabilityNullable        Nullability = "Nullable"
+	NullabilityNullableUnknown Nullability = "NullableUnknown"
+
+	// KnownNullability is the list of valid Nullability
+	KnownNullability = []Nullability{
+		NullabilityNoNulls,
+		NullabilityNullable,
+		NullabilityNullableUnknown,
+	}
+	// KnownNullabilityString is the list of valid Nullability as string
+	KnownNullabilityString = []string{
+		string(NullabilityNoNulls),
+		string(NullabilityNullable),
+		string(NullabilityNullableUnknown),
+	}
+
+	// InKnownNullability is an ozzo-validator for Nullability
+	InKnownNullability = validation.In(
+		NullabilityNoNulls,
+		NullabilityNullable,
+		NullabilityNullableUnknown,
+	)
+)

--- a/pkg/generators/models/testdata/cases/allof_mixin_skipping/generated/model_column_metadata.go
+++ b/pkg/generators/models/testdata/cases/allof_mixin_skipping/generated/model_column_metadata.go
@@ -1,0 +1,59 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// ColumnMetadata is an object. Metadata for single column
+type ColumnMetadata struct {
+	// Comment: Column description
+	Comment string `json:"comment,omitempty"`
+	// Name: Column name
+	Name string `json:"name"`
+	// Type: Type metadata
+	Type ColumnTypeMetadata `json:"type"`
+}
+
+// Validate implements basic validation for this model
+func (m ColumnMetadata) Validate() error {
+	return validation.Errors{
+		"type": validation.Validate(
+			m.Type, validation.NotNil,
+		),
+	}.Filter()
+}
+
+// GetComment returns the Comment property
+func (m ColumnMetadata) GetComment() string {
+	return m.Comment
+}
+
+// SetComment sets the Comment property
+func (m *ColumnMetadata) SetComment(val string) {
+	m.Comment = val
+}
+
+// GetName returns the Name property
+func (m ColumnMetadata) GetName() string {
+	return m.Name
+}
+
+// SetName sets the Name property
+func (m *ColumnMetadata) SetName(val string) {
+	m.Name = val
+}
+
+// GetType returns the Type property
+func (m ColumnMetadata) GetType() ColumnTypeMetadata {
+	return m.Type
+}
+
+// SetType sets the Type property
+func (m *ColumnMetadata) SetType(val ColumnTypeMetadata) {
+	m.Type = val
+}

--- a/pkg/generators/models/testdata/cases/allof_mixin_skipping/generated/model_column_type.go
+++ b/pkg/generators/models/testdata/cases/allof_mixin_skipping/generated/model_column_type.go
@@ -1,0 +1,84 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// ColumnType is an enum. Normalized column type. If type cannot be determined or is not compatible, then 'other'.
+type ColumnType string
+
+// Validate implements basic validation for this model
+func (m ColumnType) Validate() error {
+	return InKnownColumnType.Validate(m)
+}
+
+var (
+	ColumnTypeBigint          ColumnType = "bigint"
+	ColumnTypeBoolean         ColumnType = "boolean"
+	ColumnTypeDate            ColumnType = "date"
+	ColumnTypeDoublePrecision ColumnType = "double precision"
+	ColumnTypeFloat           ColumnType = "float"
+	ColumnTypeInteger         ColumnType = "integer"
+	ColumnTypeNumeric         ColumnType = "numeric"
+	ColumnTypeOther           ColumnType = "other"
+	ColumnTypeSmallint        ColumnType = "smallint"
+	ColumnTypeTime            ColumnType = "time"
+	ColumnTypeTimestamp       ColumnType = "timestamp"
+	ColumnTypeVarchar         ColumnType = "varchar"
+	ColumnTypeVarcharArray    ColumnType = "varchar array"
+
+	// KnownColumnType is the list of valid ColumnType
+	KnownColumnType = []ColumnType{
+		ColumnTypeBigint,
+		ColumnTypeBoolean,
+		ColumnTypeDate,
+		ColumnTypeDoublePrecision,
+		ColumnTypeFloat,
+		ColumnTypeInteger,
+		ColumnTypeNumeric,
+		ColumnTypeOther,
+		ColumnTypeSmallint,
+		ColumnTypeTime,
+		ColumnTypeTimestamp,
+		ColumnTypeVarchar,
+		ColumnTypeVarcharArray,
+	}
+	// KnownColumnTypeString is the list of valid ColumnType as string
+	KnownColumnTypeString = []string{
+		string(ColumnTypeBigint),
+		string(ColumnTypeBoolean),
+		string(ColumnTypeDate),
+		string(ColumnTypeDoublePrecision),
+		string(ColumnTypeFloat),
+		string(ColumnTypeInteger),
+		string(ColumnTypeNumeric),
+		string(ColumnTypeOther),
+		string(ColumnTypeSmallint),
+		string(ColumnTypeTime),
+		string(ColumnTypeTimestamp),
+		string(ColumnTypeVarchar),
+		string(ColumnTypeVarcharArray),
+	}
+
+	// InKnownColumnType is an ozzo-validator for ColumnType
+	InKnownColumnType = validation.In(
+		ColumnTypeBigint,
+		ColumnTypeBoolean,
+		ColumnTypeDate,
+		ColumnTypeDoublePrecision,
+		ColumnTypeFloat,
+		ColumnTypeInteger,
+		ColumnTypeNumeric,
+		ColumnTypeOther,
+		ColumnTypeSmallint,
+		ColumnTypeTime,
+		ColumnTypeTimestamp,
+		ColumnTypeVarchar,
+		ColumnTypeVarcharArray,
+	)
+)

--- a/pkg/generators/models/testdata/cases/allof_mixin_skipping/generated/model_column_type_metadata.go
+++ b/pkg/generators/models/testdata/cases/allof_mixin_skipping/generated/model_column_type_metadata.go
@@ -1,0 +1,92 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// ColumnTypeMetadata is an object. Type metadata
+type ColumnTypeMetadata struct {
+	// Columns: List of columns if this type is structural
+	Columns []ColumnMetadata `json:"columns,omitempty"`
+	// ItemType: Type metadata
+	ItemType *ColumnTypeMetadata `json:"itemType,omitempty"`
+	// Nullable: Column nullability
+	Nullable Nullability `json:"nullable"`
+	// OriginalName: Original column type as given by data source
+	OriginalName string `json:"originalName"`
+	// Type: Normalized column type. If type cannot be determined or is not compatible, then 'other'.
+	Type ColumnType `json:"type"`
+}
+
+// Validate implements basic validation for this model
+func (m ColumnTypeMetadata) Validate() error {
+	return validation.Errors{
+		"columns": validation.Validate(
+			m.Columns,
+		),
+		"itemType": validation.Validate(
+			m.ItemType,
+		),
+		"nullable": validation.Validate(
+			m.Nullable, validation.Required,
+		),
+		"type": validation.Validate(
+			m.Type, validation.Required,
+		),
+	}.Filter()
+}
+
+// GetColumns returns the Columns property
+func (m ColumnTypeMetadata) GetColumns() []ColumnMetadata {
+	return m.Columns
+}
+
+// SetColumns sets the Columns property
+func (m *ColumnTypeMetadata) SetColumns(val []ColumnMetadata) {
+	m.Columns = val
+}
+
+// GetItemType returns the ItemType property
+func (m ColumnTypeMetadata) GetItemType() *ColumnTypeMetadata {
+	return m.ItemType
+}
+
+// SetItemType sets the ItemType property
+func (m *ColumnTypeMetadata) SetItemType(val *ColumnTypeMetadata) {
+	m.ItemType = val
+}
+
+// GetNullable returns the Nullable property
+func (m ColumnTypeMetadata) GetNullable() Nullability {
+	return m.Nullable
+}
+
+// SetNullable sets the Nullable property
+func (m *ColumnTypeMetadata) SetNullable(val Nullability) {
+	m.Nullable = val
+}
+
+// GetOriginalName returns the OriginalName property
+func (m ColumnTypeMetadata) GetOriginalName() string {
+	return m.OriginalName
+}
+
+// SetOriginalName sets the OriginalName property
+func (m *ColumnTypeMetadata) SetOriginalName(val string) {
+	m.OriginalName = val
+}
+
+// GetType returns the Type property
+func (m ColumnTypeMetadata) GetType() ColumnType {
+	return m.Type
+}
+
+// SetType sets the Type property
+func (m *ColumnTypeMetadata) SetType(val ColumnType) {
+	m.Type = val
+}

--- a/pkg/generators/models/testdata/cases/allof_mixin_skipping/generated/model_nullability.go
+++ b/pkg/generators/models/testdata/cases/allof_mixin_skipping/generated/model_nullability.go
@@ -1,0 +1,44 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Nullability is an enum. Column nullability
+type Nullability string
+
+// Validate implements basic validation for this model
+func (m Nullability) Validate() error {
+	return InKnownNullability.Validate(m)
+}
+
+var (
+	NullabilityNoNulls         Nullability = "NoNulls"
+	NullabilityNullable        Nullability = "Nullable"
+	NullabilityNullableUnknown Nullability = "NullableUnknown"
+
+	// KnownNullability is the list of valid Nullability
+	KnownNullability = []Nullability{
+		NullabilityNoNulls,
+		NullabilityNullable,
+		NullabilityNullableUnknown,
+	}
+	// KnownNullabilityString is the list of valid Nullability as string
+	KnownNullabilityString = []string{
+		string(NullabilityNoNulls),
+		string(NullabilityNullable),
+		string(NullabilityNullableUnknown),
+	}
+
+	// InKnownNullability is an ozzo-validator for Nullability
+	InKnownNullability = validation.In(
+		NullabilityNoNulls,
+		NullabilityNullable,
+		NullabilityNullableUnknown,
+	)
+)

--- a/pkg/generators/models/testdata/cases/allof_self_reference/api.yaml
+++ b/pkg/generators/models/testdata/cases/allof_self_reference/api.yaml
@@ -11,9 +11,7 @@ components:
         value:
           type: string
         next:
+          description: the next item
           allOf:
             - $ref: "#/components/schemas/ListItem"
-            - description: the next item
             - nullable: true
-    
- 


### PR DESCRIPTION
Add logic to skip semantically empty schemas inside an allOf. For
example, skipping items that only modify the description. It would be
better to bubble up some of this metadata, but this would require a
significant refactor of the object handling. This change should reduce
the number of situations that result in inline structs being generated,
thus improving the resulting code quality. The tradeoff is that the code
comments are a little less good. But the improved types seem to be worth
it.

## Ticket
<!-- Paste the url for the jira task/bug or Github issue here -->
None, this resolves an issue in Hub which is caused by #48 

## How Has This Been Verified?
<!--- Please describe in detail how you tested your changes. -->
A new unit test has been added that copies the troublesome api schema  and verifies that it generates the expected model (modulo the description)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [ ] New code can be debugged via logs.
- [x] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
