### PR TITLE
feat: Reimplement description merging on allOfs

### DIFF
--- a/pkg/generators/models/models_test.go
+++ b/pkg/generators/models/models_test.go
@@ -14,121 +14,126 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestModels(t *testing.T) {
-	cases := []struct {
-		name      string
-		directory string
-	}{
-		{
-			name:      "simple model",
-			directory: "testdata/cases/simple_model",
-		},
-		{
-			name:      "validation",
-			directory: "testdata/cases/validation",
-		},
-		{
-			name:      "embedded type",
-			directory: "testdata/cases/embedded_type",
-		},
-		{
-			name:      "required property removes omitempty",
-			directory: "testdata/cases/required_properties",
-		},
-		{
-			name:      "nullable converts to pointer",
-			directory: "testdata/cases/nullable_properties",
-		},
-		{
-			name:      "untyped object converts to map[string]interface{}",
-			directory: "testdata/cases/untyped_object",
-		},
-		{
-			name:      "oneOf converts to interface{}",
-			directory: "testdata/cases/oneof",
-		},
-		{
-			name:      "allOf merges multiple inlined object definitions on property level",
-			directory: "testdata/cases/allof1",
-		},
-		{
-			name:      "allOf merges multiple inlined object definitions on top level",
-			directory: "testdata/cases/allof2",
-		},
-		{
-			name:      "allOf merges refs and inlined object definitions",
-			directory: "testdata/cases/allof3",
-		},
-		{
-			name:      "allOf can be used in conjunction with nullable to produce pointers to other types",
-			directory: "testdata/cases/allof4",
-		},
-		{
-			name:      "allOf can flatten fields and inline as subtypes of a struct",
-			directory: "testdata/cases/allof5",
-		},
-		{
-			name:      "allOf can skip certain mixins",
-			directory: "testdata/cases/allof_mixin_skipping",
-		},
-		{
-			name:      "typed arrays generated typed arrays in go",
-			directory: "testdata/cases/typed_arrays",
-		},
-		{
-			name:      "if the array prop is nullable it is NOT converted to a pointer (slices are already nullable in go)",
-			directory: "testdata/cases/nullable_arrays",
-		},
-		{
-			name:      "if an untyped object prop is nullable it is NOT converted to a pointer (maps are already nullable in go)",
-			directory: "testdata/cases/nullable_untyped_object",
-		},
-		{
-			name:      "an untyped object may have additional properties of a specific type",
-			directory: "testdata/cases/object_with_additional_properties",
-		},
-		{
-			name:      "an untyped toplevel object may have additional properties of a specific type",
-			directory: "testdata/cases/toplevel_object_with_additional_properties",
-		},
-		{
-			name:      "handles string enums",
-			directory: "testdata/cases/enum",
-		},
-		{
-			name:      "enum with one item",
-			directory: "testdata/cases/enum_with_one_item",
-		},
-		{
-			name:      "model from path body",
-			directory: "testdata/cases/model_from_path_body",
-		},
-		{
-			name:      "enum with name collision",
-			directory: "testdata/cases/enum_with_name_collision",
-		},
-		{
-			name:      "model from path parameters",
-			directory: "testdata/cases/parameter_model",
-		},
-		{
-			name:      "model with recursive definition within an allof",
-			directory: "testdata/cases/allof_self_reference",
-		},
-		{
-			name:      "allof merges required list",
-			directory: "testdata/cases/allof_merges_required_list",
-		},
-		{
-			name:      "allof merges enum list",
-			directory: "testdata/cases/allof_enum",
-		},
-		{
-			name:      "allof supports intermediate array types",
-			directory: "testdata/cases/allof_arrays",
-		},
-	}
+var cases = []struct {
+	name      string
+	directory string
+}{
+	{
+		name:      "simple model",
+		directory: "testdata/cases/simple_model",
+	},
+	{
+		name:      "validation",
+		directory: "testdata/cases/validation",
+	},
+	{
+		name:      "embedded type",
+		directory: "testdata/cases/embedded_type",
+	},
+	{
+		name:      "required property removes omitempty",
+		directory: "testdata/cases/required_properties",
+	},
+	{
+		name:      "nullable converts to pointer",
+		directory: "testdata/cases/nullable_properties",
+	},
+	{
+		// 5
+		name:      "untyped object converts to map[string]interface{}",
+		directory: "testdata/cases/untyped_object",
+	},
+	{
+		name:      "oneOf converts to interface{}",
+		directory: "testdata/cases/oneof",
+	},
+	{
+		name:      "allOf merges multiple inlined object definitions on property level",
+		directory: "testdata/cases/allof1",
+	},
+	{
+		name:      "allOf merges multiple inlined object definitions on top level",
+		directory: "testdata/cases/allof2",
+	},
+	{
+		name:      "allOf merges refs and inlined object definitions",
+		directory: "testdata/cases/allof3",
+	},
+	{
+		// 10
+		name:      "allOf can be used in conjunction with nullable to produce pointers to other types",
+		directory: "testdata/cases/allof4",
+	},
+	{
+		name:      "allOf can flatten fields and inline as subtypes of a struct",
+		directory: "testdata/cases/allof5",
+	},
+	{
+		name:      "allOf can skip certain mixins",
+		directory: "testdata/cases/allof_mixin_skipping",
+	},
+	{
+		name:      "typed arrays generated typed arrays in go",
+		directory: "testdata/cases/typed_arrays",
+	},
+	{
+		name:      "if the array prop is nullable it is NOT converted to a pointer (slices are already nullable in go)",
+		directory: "testdata/cases/nullable_arrays",
+	},
+	{
+		// 15
+		name:      "if an untyped object prop is nullable it is NOT converted to a pointer (maps are already nullable in go)",
+		directory: "testdata/cases/nullable_untyped_object",
+	},
+	{
+		name:      "an untyped object may have additional properties of a specific type",
+		directory: "testdata/cases/object_with_additional_properties",
+	},
+	{
+		name:      "an untyped toplevel object may have additional properties of a specific type",
+		directory: "testdata/cases/toplevel_object_with_additional_properties",
+	},
+	{
+		name:      "handles string enums",
+		directory: "testdata/cases/enum",
+	},
+	{
+		name:      "enum with one item",
+		directory: "testdata/cases/enum_with_one_item",
+	},
+	{
+		// 20
+		name:      "model from path body",
+		directory: "testdata/cases/model_from_path_body",
+	},
+	{
+		name:      "enum with name collision",
+		directory: "testdata/cases/enum_with_name_collision",
+	},
+	{
+		name:      "model from path parameters",
+		directory: "testdata/cases/parameter_model",
+	},
+	{
+		name:      "model with recursive definition within an allof",
+		directory: "testdata/cases/allof_self_reference",
+	},
+	{
+		name:      "allof merges required list",
+		directory: "testdata/cases/allof_merges_required_list",
+	},
+	{
+		// 25
+		name:      "allof merges enum list",
+		directory: "testdata/cases/allof_enum",
+	},
+	{
+		name:      "allof supports intermediate array types",
+		directory: "testdata/cases/allof_arrays",
+	},
+}
 
+func TestModels(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.
@@ -169,6 +174,44 @@ func TestModels(t *testing.T) {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		require.NoError(t, cmd.Run())
+	})
+}
+
+func TestModelsSingleCase(t *testing.T) {
+	t.Skip("only used during local development")
+
+	tc := cases[5]
+	t.Run(tc.name, func(t *testing.T) {
+		ctx, cancel := context.
+			WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		dir := filepath.Join(tc.directory, "generated")
+		err := os.MkdirAll(dir, 0755)
+		require.NoError(t, err)
+		bs, err := ioutil.ReadFile(filepath.Join(tc.directory, "api.yaml"))
+		require.NoError(t, err)
+		reader := bytes.NewReader(bs)
+
+		g, err := NewGenerator(reader, Options{
+			PackageName: "generatortest",
+			Destination: dir,
+			// Logger:      log.Logger.Output(zerolog.ConsoleWriter{Out: os.Stderr}),
+			Logger: log.Output(ioutil.Discard), // swap for debugging
+		})
+		require.NoError(t, err)
+
+		err = g.Generate(ctx)
+		require.NoError(t, err)
+
+		files, err := filepath.Glob(filepath.Join(dir, "*"))
+		require.NoError(t, err)
+		for _, f := range files {
+			equalFiles(t,
+				filepath.Join(tc.directory, "expected", filepath.Base(f)),
+				filepath.Join(tc.directory, "generated", filepath.Base(f)),
+			)
+		}
 	})
 }
 

--- a/pkg/generators/models/testdata/cases/allof_mixin_skipping/expected/model_column_metadata.go
+++ b/pkg/generators/models/testdata/cases/allof_mixin_skipping/expected/model_column_metadata.go
@@ -15,7 +15,7 @@ type ColumnMetadata struct {
 	Comment string `json:"comment,omitempty"`
 	// Name: Column name
 	Name string `json:"name"`
-	// Type: Type metadata
+	// Type: Type metadata Column type
 	Type ColumnTypeMetadata `json:"type"`
 }
 

--- a/pkg/generators/models/testdata/cases/allof_mixin_skipping/expected/model_column_type_metadata.go
+++ b/pkg/generators/models/testdata/cases/allof_mixin_skipping/expected/model_column_type_metadata.go
@@ -13,13 +13,13 @@ import (
 type ColumnTypeMetadata struct {
 	// Columns: List of columns if this type is structural
 	Columns []ColumnMetadata `json:"columns,omitempty"`
-	// ItemType: Type metadata
+	// ItemType: Type metadata Array item type if this type is array
 	ItemType *ColumnTypeMetadata `json:"itemType,omitempty"`
 	// Nullable: Column nullability
 	Nullable Nullability `json:"nullable"`
 	// OriginalName: Original column type as given by data source
 	OriginalName string `json:"originalName"`
-	// Type: Normalized column type. If type cannot be determined or is not compatible, then 'other'.
+	// Type: Normalized column type. If type cannot be determined or is not compatible, then 'other'. Column type
 	Type ColumnType `json:"type"`
 }
 

--- a/pkg/generators/models/testdata/cases/allof_mixin_skipping/generated/model_column_metadata.go
+++ b/pkg/generators/models/testdata/cases/allof_mixin_skipping/generated/model_column_metadata.go
@@ -15,7 +15,7 @@ type ColumnMetadata struct {
 	Comment string `json:"comment,omitempty"`
 	// Name: Column name
 	Name string `json:"name"`
-	// Type: Type metadata
+	// Type: Type metadata Column type
 	Type ColumnTypeMetadata `json:"type"`
 }
 

--- a/pkg/generators/models/testdata/cases/allof_mixin_skipping/generated/model_column_type_metadata.go
+++ b/pkg/generators/models/testdata/cases/allof_mixin_skipping/generated/model_column_type_metadata.go
@@ -13,13 +13,13 @@ import (
 type ColumnTypeMetadata struct {
 	// Columns: List of columns if this type is structural
 	Columns []ColumnMetadata `json:"columns,omitempty"`
-	// ItemType: Type metadata
+	// ItemType: Type metadata Array item type if this type is array
 	ItemType *ColumnTypeMetadata `json:"itemType,omitempty"`
 	// Nullable: Column nullability
 	Nullable Nullability `json:"nullable"`
 	// OriginalName: Original column type as given by data source
 	OriginalName string `json:"originalName"`
-	// Type: Normalized column type. If type cannot be determined or is not compatible, then 'other'.
+	// Type: Normalized column type. If type cannot be determined or is not compatible, then 'other'. Column type
 	Type ColumnType `json:"type"`
 }
 


### PR DESCRIPTION
This reimplements the description merging/concatenation on allOfs. This
should result in better doc strings. This requires some new logic to
concatenate the doc strings and to enhacing the logic to determine when
we inline or reference types.

Additionally rename some internal methods to have better semantic
meaning.

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>


<!-- Summary of changes above here -->

## Ticket
<!-- Paste the url for the jira task/bug or Github issue here -->

## How Has This Been Verified?
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The change works as expected.
- [ ] New code can be debugged via logs.
- [ ] I have added tests to cover my changes.
- [ ] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
