### PR TITLE
fix: prevent validation loop in discriminated oneOf

### DIFF
--- a/pkg/generators/models/templates/oneof.gotpl
+++ b/pkg/generators/models/templates/oneof.gotpl
@@ -107,7 +107,7 @@ func (m {{$modelName}}) Validate() error {
 	switch discriminator {
 	{{- range $value, $type := .Discriminator.Map }}
 	case "{{$value}}":
-		return m.Validate()
+		return m.data.Validate()
 	{{- end}}
 	default:
 		return validation.Errors{

--- a/pkg/generators/models/testdata/cases/nested_inline_arrays/expected/model_geometry.go
+++ b/pkg/generators/models/testdata/cases/nested_inline_arrays/expected/model_geometry.go
@@ -96,9 +96,9 @@ func (m Geometry) Validate() error {
 	discriminator := m.data.GeometryDiscriminator()
 	switch discriminator {
 	case "Line":
-		return m.Validate()
+		return m.data.Validate()
 	case "Shape":
-		return m.Validate()
+		return m.data.Validate()
 	default:
 		return validation.Errors{
 			"type": fmt.Errorf("unknown type value"),

--- a/pkg/generators/models/testdata/cases/nested_inline_arrays/generated/model_geometry.go
+++ b/pkg/generators/models/testdata/cases/nested_inline_arrays/generated/model_geometry.go
@@ -96,9 +96,9 @@ func (m Geometry) Validate() error {
 	discriminator := m.data.GeometryDiscriminator()
 	switch discriminator {
 	case "Line":
-		return m.Validate()
+		return m.data.Validate()
 	case "Shape":
-		return m.Validate()
+		return m.data.Validate()
 	default:
 		return validation.Errors{
 			"type": fmt.Errorf("unknown type value"),

--- a/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/api.yaml
+++ b/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/api.yaml
@@ -69,9 +69,11 @@ components:
         service:
           type: string
           description: name of the service that is returning errors
+          minLength: 1
         traceId:
           type: string
           description: the request tracing id, this can be submitted during bug reports to help with debugging the underlying cause.
+          minLength: 1
       required:
         - kind
         - traceId

--- a/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/expected/mode_test.go
+++ b/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/expected/mode_test.go
@@ -58,3 +58,14 @@ func TestSerialization(t *testing.T) {
 	})
 
 }
+
+func TestValidation(t *testing.T) {
+	rawMsg := `{"kind": "external", "service": "", "traceId": ""}`
+	resp := Error{}
+
+	err := json.Unmarshal([]byte(rawMsg), &resp)
+	require.NoError(t, err)
+
+	err = resp.Validate()
+	require.EqualError(t, err, "traceId: cannot be blank.")
+}

--- a/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/expected/model_error.go
+++ b/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/expected/model_error.go
@@ -120,13 +120,13 @@ func (m Error) Validate() error {
 	discriminator := m.data.ErrorDiscriminator()
 	switch discriminator {
 	case "auth":
-		return m.Validate()
+		return m.data.Validate()
 	case "external":
-		return m.Validate()
+		return m.data.Validate()
 	case "field":
-		return m.Validate()
+		return m.data.Validate()
 	case "generic":
-		return m.Validate()
+		return m.data.Validate()
 	default:
 		return validation.Errors{
 			"kind": fmt.Errorf("unknown kind value"),

--- a/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/expected/model_external_error.go
+++ b/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/expected/model_external_error.go
@@ -21,7 +21,14 @@ type ExternalError struct {
 
 // Validate implements basic validation for this model
 func (m ExternalError) Validate() error {
-	return validation.Errors{}.Filter()
+	return validation.Errors{
+		"service": validation.Validate(
+			m.Service, validation.Length(1, 0),
+		),
+		"traceId": validation.Validate(
+			m.TraceId, validation.Required, validation.Length(1, 0),
+		),
+	}.Filter()
 }
 
 // GetKind returns the Kind property

--- a/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/generated/model_error.go
+++ b/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/generated/model_error.go
@@ -120,13 +120,13 @@ func (m Error) Validate() error {
 	discriminator := m.data.ErrorDiscriminator()
 	switch discriminator {
 	case "auth":
-		return m.Validate()
+		return m.data.Validate()
 	case "external":
-		return m.Validate()
+		return m.data.Validate()
 	case "field":
-		return m.Validate()
+		return m.data.Validate()
 	case "generic":
-		return m.Validate()
+		return m.data.Validate()
 	default:
 		return validation.Errors{
 			"kind": fmt.Errorf("unknown kind value"),

--- a/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/generated/model_external_error.go
+++ b/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/generated/model_external_error.go
@@ -21,7 +21,14 @@ type ExternalError struct {
 
 // Validate implements basic validation for this model
 func (m ExternalError) Validate() error {
-	return validation.Errors{}.Filter()
+	return validation.Errors{
+		"service": validation.Validate(
+			m.Service, validation.Length(1, 0),
+		),
+		"traceId": validation.Validate(
+			m.TraceId, validation.Required, validation.Length(1, 0),
+		),
+	}.Filter()
 }
 
 // GetKind returns the Kind property

--- a/pkg/generators/models/testdata/cases/oneof_unmapped_discriminator/expected/model_error.go
+++ b/pkg/generators/models/testdata/cases/oneof_unmapped_discriminator/expected/model_error.go
@@ -113,11 +113,11 @@ func (m Error) Validate() error {
 	discriminator := m.data.ErrorDiscriminator()
 	switch discriminator {
 	case "ExternalError":
-		return m.Validate()
+		return m.data.Validate()
 	case "FieldError":
-		return m.Validate()
+		return m.data.Validate()
 	case "GenericError":
-		return m.Validate()
+		return m.data.Validate()
 	default:
 		return validation.Errors{
 			"kind": fmt.Errorf("unknown kind value"),

--- a/pkg/generators/models/testdata/cases/oneof_unmapped_discriminator/generated/model_error.go
+++ b/pkg/generators/models/testdata/cases/oneof_unmapped_discriminator/generated/model_error.go
@@ -113,11 +113,11 @@ func (m Error) Validate() error {
 	discriminator := m.data.ErrorDiscriminator()
 	switch discriminator {
 	case "ExternalError":
-		return m.Validate()
+		return m.data.Validate()
 	case "FieldError":
-		return m.Validate()
+		return m.data.Validate()
 	case "GenericError":
-		return m.Validate()
+		return m.data.Validate()
 	default:
 		return validation.Errors{
 			"kind": fmt.Errorf("unknown kind value"),


### PR DESCRIPTION
Call the correct validation method instead of creating a validation loop
recusion loop. Add a test to verify that valdiation does return an error
as expected, instead of a panic.

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>

## Ticket
<!-- Paste the url for the jira task/bug or Github issue here -->
NA found it while trying to add a new discriminated oneOf in hub

## How Has This Been Verified?
<!--- Please describe in detail how you tested your changes. -->
New unit test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [ ] New code can be debugged via logs.
- [x] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
