### PR TITLE
feat: use enum for discriminators

### DIFF
--- a/pkg/generators/models/models_test.go
+++ b/pkg/generators/models/models_test.go
@@ -196,7 +196,7 @@ func TestModels(t *testing.T) {
 func TestModelsSingleCase(t *testing.T) {
 	t.Skip("only used during local development")
 
-	tc := cases[1]
+	tc := cases[27]
 	t.Run(tc.name, func(t *testing.T) {
 		ctx, cancel := context.
 			WithTimeout(context.Background(), 30*time.Second)

--- a/pkg/generators/models/templates/oneof.gotpl
+++ b/pkg/generators/models/templates/oneof.gotpl
@@ -20,8 +20,19 @@ import (
 
 
 {{- if .Discriminator.Field }}
+// {{$modelName}}Discriminator is the discriminator value used during serialization and validation.
+// Retrieve this value using  the {{$modelName}}Discriminator() method
+type {{$modelName}}Discriminator string
+
+const (
+{{- range $value, $type := .Discriminator.Map }}
+	// {{$modelName}}Discriminator{{$value | toPascalCase | firstUpper}} maps {{$modelName}} to {{$type}}
+	{{$modelName}}Discriminator{{$value | toPascalCase | firstUpper}} {{$modelName}}Discriminator = "{{$value}}"
+{{- end}}
+)
+
 type {{$interfaceName}} interface {
-	{{$modelName}}Discriminator() string
+	{{$modelName}}Discriminator() {{$modelName}}Discriminator
 	Validate() error
 }
 {{- end}}
@@ -58,9 +69,10 @@ func (m *{{$modelName}}) UnmarshalJSON(bs []byte) error {
 		}.Filter()
 	}
 
-	switch discriminator.Value {
+	value := fmt.Sprintf("%v",discriminator.Value)
+	switch {{$modelName}}Discriminator(value) {
 	{{- range $value, $type := .Discriminator.Map }}
-	case "{{$value}}":
+	case {{$modelName}}Discriminator{{$value | toPascalCase | firstUpper}}:
 		data := {{$type|toPascalCase}}{}
 		err := json.Unmarshal(bs, &data)
 		if err != nil {
@@ -101,12 +113,17 @@ func (m {{$modelName}}) As{{$convert.TargetGoType | typeDisplayName }}() (result
 
 
 {{ if .Discriminator.Field }}
+// Discriminator returns the {{$modelName}}Discriminator oneOf value
+func (m {{$modelName}}) Discriminator() {{$modelName}}Discriminator {
+	return m.data.{{$modelName}}Discriminator()
+}
+
 // Validate implements basic validation for this model
 func (m {{$modelName}}) Validate() error {
 	discriminator := m.data.{{$modelName}}Discriminator()
 	switch discriminator {
 	{{- range $value, $type := .Discriminator.Map }}
-	case "{{$value}}":
+	case {{$modelName}}Discriminator{{$value | toPascalCase | firstUpper}}:
 		return m.data.Validate()
 	{{- end}}
 	default:
@@ -126,7 +143,7 @@ func Is{{$modelName}}(data interface{}) bool {
 	discriminator := t.{{$modelName}}Discriminator()
 	switch discriminator {
 	{{- range $value, $type := .Discriminator.Map }}
-	case "{{$value}}":
+	case {{$modelName}}Discriminator{{$value | toPascalCase | firstUpper}}:
 		return true
 	{{- end}}
 	default:
@@ -135,9 +152,10 @@ func Is{{$modelName}}(data interface{}) bool {
 }
 
 {{- range $convert := .ConvertSpecs }}
-// {{$modelName}}Discriminator implements {{$interfaceName}} and returns the discriminator value as a string.
-func (m {{$convert.TargetGoType}}) {{$modelName}}Discriminator() string {
-	return string(m.Get{{$discriminator}}())
+// {{$modelName}}Discriminator implements {{$interfaceName}} and returns the discriminator value.
+func (m {{$convert.TargetGoType}}) {{$modelName}}Discriminator() {{$modelName}}Discriminator {
+	value := fmt.Sprintf("%v", m.Get{{$discriminator}}())
+	return {{$modelName}}Discriminator(value)
 }
 
 {{- end }}


### PR DESCRIPTION
Create an enum for the oneOf discriminator values. This then allows for linting checks such as 	https://github.com/nishanths/exhaustive to verify that all cases are handled.

This also improves casting of the discriminator value to match the documentation in the spec
https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#discriminatorObject,
specifically. `The mapping` is defined as `Map[string, string]` and it notes

> Mapping keys MUST be string values, but tooling MAY convert response values to strings for comparison.

So we can now support non-string discriminator values because we use string formatting to cast the value.


## Ticket
<!-- Paste the url for the jira task/bug or Github issue here -->

## How Has This Been Verified?
<!--- Please describe in detail how you tested your changes. -->
Updated unit test.

I also verified that `exhaustive` will in-fact cause a linting error if you miss a value in a switch. When you run `exhaustive` on this file:

```go
// check.go
package generatortest

func check() bool {

	foo := Error{}
	switch foo.ErrorDiscriminator() {
	case ErrorDiscriminatorAuth:
		return true
	}
	return false
}
```
It produces 

```sh
check.go:6:2: missing cases in switch of type ErrorDiscriminator: ErrorDiscriminatorExternal, ErrorDiscriminatorField, ErrorDiscriminatorGeneric
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [ ] New code can be debugged via logs.
- [x] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
