### PR TITLE
fix: sort model names prior to generation to improve stability

### DIFF
--- a/pkg/generators/models/generate.go
+++ b/pkg/generators/models/generate.go
@@ -139,7 +139,8 @@ func (g generator) Generate(ctx context.Context) (err error) {
 	log.Debug().Msg("Paths have been processed.")
 
 	log.Debug().Msg("Processing schemas...")
-	for name, ref := range g.spec.Components.Schemas {
+	for _, name := range sortedKeys(g.spec.Components.Schemas) {
+		ref := g.spec.Components.Schemas[name]
 		err = ctx.Err()
 		if err != nil {
 			return err

--- a/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/api.yaml
+++ b/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/api.yaml
@@ -1,0 +1,62 @@
+openapi: 3.0.0
+info:
+  version: 0.1.0
+  title: Test
+
+components:
+  schemas:
+    Connection:
+      type: object
+      required:
+        - createdAt
+        - updatedAt
+        - id
+        - name
+        - technology
+        - properties
+      properties:
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          minLength: 2
+          maxLength: 255
+          pattern: ^([a-zA-z_]+[a-z0-9_]*){2}$
+        technology:
+          allOf:
+            - $ref: "#/components/schemas/ConnectionTechnology"
+        properties:
+          $ref: "#/components/schemas/ConnectionProperties"
+
+    ConnectionProperties:
+      type: object
+
+    ConnectionTechnology:
+      description: "The connection technology is either the technology value of the related data source or the integration type"
+      allOf:
+        - $ref: "#/components/schemas/DataSourceTechnology"
+        - $ref: "#/components/schemas/IntegrationType"
+
+    DataSourceTechnology:
+      type: string
+      description: |
+          Technology of a data source. For external data sources this also specifies the type of connection (driver) being used to connect to the data source. Generic data sources may use any technology value (but no connection will be established). Generic data sources may also use the value "other" for technology in case no technology should be shown in the catalog or the technology is not known to the catalog.
+      enum:
+          - mssql
+          - mysql
+          - oracle
+          - postgresql
+          - other
+
+    IntegrationType:
+      type: string
+      enum:
+        - generic
+        - tableau

--- a/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/expected/model_connection.go
+++ b/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/expected/model_connection.go
@@ -1,0 +1,112 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"time"
+
+	"github.com/go-ozzo/ozzo-validation/v4/is"
+
+	"regexp"
+)
+
+// connectionNamePattern is the validation pattern for Connection.Name
+var connectionNamePattern = regexp.MustCompile(`^([a-zA-z_]+[a-z0-9_]*){2}$`)
+
+// Connection is an object.
+type Connection struct {
+	// CreatedAt:
+	CreatedAt time.Time `json:"createdAt"`
+	// Id:
+	Id string `json:"id"`
+	// Name:
+	Name string `json:"name"`
+	// Properties:
+	Properties ConnectionProperties `json:"properties"`
+	// Technology: The connection technology is either the technology value of the related data source or the integration type
+	Technology ConnectionTechnology `json:"technology"`
+	// UpdatedAt:
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// Validate implements basic validation for this model
+func (m Connection) Validate() error {
+	return validation.Errors{
+		"id": validation.Validate(
+			m.Id, validation.Required, is.UUID,
+		),
+		"name": validation.Validate(
+			m.Name, validation.Required, validation.Length(2, 255), validation.Match(connectionNamePattern),
+		),
+		"properties": validation.Validate(
+			m.Properties, validation.NotNil,
+		),
+		"technology": validation.Validate(
+			m.Technology, validation.NotNil,
+		),
+	}.Filter()
+}
+
+// GetCreatedAt returns the CreatedAt property
+func (m Connection) GetCreatedAt() time.Time {
+	return m.CreatedAt
+}
+
+// SetCreatedAt sets the CreatedAt property
+func (m *Connection) SetCreatedAt(val time.Time) {
+	m.CreatedAt = val
+}
+
+// GetId returns the Id property
+func (m Connection) GetId() string {
+	return m.Id
+}
+
+// SetId sets the Id property
+func (m *Connection) SetId(val string) {
+	m.Id = val
+}
+
+// GetName returns the Name property
+func (m Connection) GetName() string {
+	return m.Name
+}
+
+// SetName sets the Name property
+func (m *Connection) SetName(val string) {
+	m.Name = val
+}
+
+// GetProperties returns the Properties property
+func (m Connection) GetProperties() ConnectionProperties {
+	return m.Properties
+}
+
+// SetProperties sets the Properties property
+func (m *Connection) SetProperties(val ConnectionProperties) {
+	m.Properties = val
+}
+
+// GetTechnology returns the Technology property
+func (m Connection) GetTechnology() ConnectionTechnology {
+	return m.Technology
+}
+
+// SetTechnology sets the Technology property
+func (m *Connection) SetTechnology(val ConnectionTechnology) {
+	m.Technology = val
+}
+
+// GetUpdatedAt returns the UpdatedAt property
+func (m Connection) GetUpdatedAt() time.Time {
+	return m.UpdatedAt
+}
+
+// SetUpdatedAt sets the UpdatedAt property
+func (m *Connection) SetUpdatedAt(val time.Time) {
+	m.UpdatedAt = val
+}

--- a/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/expected/model_connection_properties.go
+++ b/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/expected/model_connection_properties.go
@@ -9,23 +9,10 @@ import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
-// Sub is an object.
-type Sub struct {
-	// Foo:
-	Foo string `json:"foo,omitempty"`
-}
+// ConnectionProperties is an object.
+type ConnectionProperties map[string]interface{}
 
 // Validate implements basic validation for this model
-func (m Sub) Validate() error {
+func (m ConnectionProperties) Validate() error {
 	return validation.Errors{}.Filter()
-}
-
-// GetFoo returns the Foo property
-func (m Sub) GetFoo() string {
-	return m.Foo
-}
-
-// SetFoo sets the Foo property
-func (m Sub) SetFoo(val string) {
-	m.Foo = val
 }

--- a/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/expected/model_connection_technology.go
+++ b/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/expected/model_connection_technology.go
@@ -1,0 +1,60 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// ConnectionTechnology is an enum. The connection technology is either the technology value of the related data source or the integration type
+type ConnectionTechnology string
+
+// Validate implements basic validation for this model
+func (m ConnectionTechnology) Validate() error {
+	return InKnownConnectionTechnology.Validate(m)
+}
+
+var (
+	ConnectionTechnologyGeneric    ConnectionTechnology = "generic"
+	ConnectionTechnologyMssql      ConnectionTechnology = "mssql"
+	ConnectionTechnologyMysql      ConnectionTechnology = "mysql"
+	ConnectionTechnologyOracle     ConnectionTechnology = "oracle"
+	ConnectionTechnologyOther      ConnectionTechnology = "other"
+	ConnectionTechnologyPostgresql ConnectionTechnology = "postgresql"
+	ConnectionTechnologyTableau    ConnectionTechnology = "tableau"
+
+	// KnownConnectionTechnology is the list of valid ConnectionTechnology
+	KnownConnectionTechnology = []ConnectionTechnology{
+		ConnectionTechnologyGeneric,
+		ConnectionTechnologyMssql,
+		ConnectionTechnologyMysql,
+		ConnectionTechnologyOracle,
+		ConnectionTechnologyOther,
+		ConnectionTechnologyPostgresql,
+		ConnectionTechnologyTableau,
+	}
+	// KnownConnectionTechnologyString is the list of valid ConnectionTechnology as string
+	KnownConnectionTechnologyString = []string{
+		string(ConnectionTechnologyGeneric),
+		string(ConnectionTechnologyMssql),
+		string(ConnectionTechnologyMysql),
+		string(ConnectionTechnologyOracle),
+		string(ConnectionTechnologyOther),
+		string(ConnectionTechnologyPostgresql),
+		string(ConnectionTechnologyTableau),
+	}
+
+	// InKnownConnectionTechnology is an ozzo-validator for ConnectionTechnology
+	InKnownConnectionTechnology = validation.In(
+		ConnectionTechnologyGeneric,
+		ConnectionTechnologyMssql,
+		ConnectionTechnologyMysql,
+		ConnectionTechnologyOracle,
+		ConnectionTechnologyOther,
+		ConnectionTechnologyPostgresql,
+		ConnectionTechnologyTableau,
+	)
+)

--- a/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/expected/model_data_source_technology.go
+++ b/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/expected/model_data_source_technology.go
@@ -1,0 +1,52 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// DataSourceTechnology is an enum. Technology of a data source. For external data sources this also specifies the type of connection (driver) being used to connect to the data source. Generic data sources may use any technology value (but no connection will be established). Generic data sources may also use the value "other" for technology in case no technology should be shown in the catalog or the technology is not known to the catalog.
+type DataSourceTechnology string
+
+// Validate implements basic validation for this model
+func (m DataSourceTechnology) Validate() error {
+	return InKnownDataSourceTechnology.Validate(m)
+}
+
+var (
+	DataSourceTechnologyMssql      DataSourceTechnology = "mssql"
+	DataSourceTechnologyMysql      DataSourceTechnology = "mysql"
+	DataSourceTechnologyOracle     DataSourceTechnology = "oracle"
+	DataSourceTechnologyOther      DataSourceTechnology = "other"
+	DataSourceTechnologyPostgresql DataSourceTechnology = "postgresql"
+
+	// KnownDataSourceTechnology is the list of valid DataSourceTechnology
+	KnownDataSourceTechnology = []DataSourceTechnology{
+		DataSourceTechnologyMssql,
+		DataSourceTechnologyMysql,
+		DataSourceTechnologyOracle,
+		DataSourceTechnologyOther,
+		DataSourceTechnologyPostgresql,
+	}
+	// KnownDataSourceTechnologyString is the list of valid DataSourceTechnology as string
+	KnownDataSourceTechnologyString = []string{
+		string(DataSourceTechnologyMssql),
+		string(DataSourceTechnologyMysql),
+		string(DataSourceTechnologyOracle),
+		string(DataSourceTechnologyOther),
+		string(DataSourceTechnologyPostgresql),
+	}
+
+	// InKnownDataSourceTechnology is an ozzo-validator for DataSourceTechnology
+	InKnownDataSourceTechnology = validation.In(
+		DataSourceTechnologyMssql,
+		DataSourceTechnologyMysql,
+		DataSourceTechnologyOracle,
+		DataSourceTechnologyOther,
+		DataSourceTechnologyPostgresql,
+	)
+)

--- a/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/expected/model_integration_type.go
+++ b/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/expected/model_integration_type.go
@@ -1,0 +1,40 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// IntegrationType is an enum.
+type IntegrationType string
+
+// Validate implements basic validation for this model
+func (m IntegrationType) Validate() error {
+	return InKnownIntegrationType.Validate(m)
+}
+
+var (
+	IntegrationTypeGeneric IntegrationType = "generic"
+	IntegrationTypeTableau IntegrationType = "tableau"
+
+	// KnownIntegrationType is the list of valid IntegrationType
+	KnownIntegrationType = []IntegrationType{
+		IntegrationTypeGeneric,
+		IntegrationTypeTableau,
+	}
+	// KnownIntegrationTypeString is the list of valid IntegrationType as string
+	KnownIntegrationTypeString = []string{
+		string(IntegrationTypeGeneric),
+		string(IntegrationTypeTableau),
+	}
+
+	// InKnownIntegrationType is an ozzo-validator for IntegrationType
+	InKnownIntegrationType = validation.In(
+		IntegrationTypeGeneric,
+		IntegrationTypeTableau,
+	)
+)

--- a/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/generated/model_connection.go
+++ b/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/generated/model_connection.go
@@ -1,0 +1,112 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"time"
+
+	"github.com/go-ozzo/ozzo-validation/v4/is"
+
+	"regexp"
+)
+
+// connectionNamePattern is the validation pattern for Connection.Name
+var connectionNamePattern = regexp.MustCompile(`^([a-zA-z_]+[a-z0-9_]*){2}$`)
+
+// Connection is an object.
+type Connection struct {
+	// CreatedAt:
+	CreatedAt time.Time `json:"createdAt"`
+	// Id:
+	Id string `json:"id"`
+	// Name:
+	Name string `json:"name"`
+	// Properties:
+	Properties ConnectionProperties `json:"properties"`
+	// Technology: The connection technology is either the technology value of the related data source or the integration type
+	Technology ConnectionTechnology `json:"technology"`
+	// UpdatedAt:
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// Validate implements basic validation for this model
+func (m Connection) Validate() error {
+	return validation.Errors{
+		"id": validation.Validate(
+			m.Id, validation.Required, is.UUID,
+		),
+		"name": validation.Validate(
+			m.Name, validation.Required, validation.Length(2, 255), validation.Match(connectionNamePattern),
+		),
+		"properties": validation.Validate(
+			m.Properties, validation.NotNil,
+		),
+		"technology": validation.Validate(
+			m.Technology, validation.NotNil,
+		),
+	}.Filter()
+}
+
+// GetCreatedAt returns the CreatedAt property
+func (m Connection) GetCreatedAt() time.Time {
+	return m.CreatedAt
+}
+
+// SetCreatedAt sets the CreatedAt property
+func (m *Connection) SetCreatedAt(val time.Time) {
+	m.CreatedAt = val
+}
+
+// GetId returns the Id property
+func (m Connection) GetId() string {
+	return m.Id
+}
+
+// SetId sets the Id property
+func (m *Connection) SetId(val string) {
+	m.Id = val
+}
+
+// GetName returns the Name property
+func (m Connection) GetName() string {
+	return m.Name
+}
+
+// SetName sets the Name property
+func (m *Connection) SetName(val string) {
+	m.Name = val
+}
+
+// GetProperties returns the Properties property
+func (m Connection) GetProperties() ConnectionProperties {
+	return m.Properties
+}
+
+// SetProperties sets the Properties property
+func (m *Connection) SetProperties(val ConnectionProperties) {
+	m.Properties = val
+}
+
+// GetTechnology returns the Technology property
+func (m Connection) GetTechnology() ConnectionTechnology {
+	return m.Technology
+}
+
+// SetTechnology sets the Technology property
+func (m *Connection) SetTechnology(val ConnectionTechnology) {
+	m.Technology = val
+}
+
+// GetUpdatedAt returns the UpdatedAt property
+func (m Connection) GetUpdatedAt() time.Time {
+	return m.UpdatedAt
+}
+
+// SetUpdatedAt sets the UpdatedAt property
+func (m *Connection) SetUpdatedAt(val time.Time) {
+	m.UpdatedAt = val
+}

--- a/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/generated/model_connection_properties.go
+++ b/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/generated/model_connection_properties.go
@@ -1,0 +1,18 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// ConnectionProperties is an object.
+type ConnectionProperties map[string]interface{}
+
+// Validate implements basic validation for this model
+func (m ConnectionProperties) Validate() error {
+	return validation.Errors{}.Filter()
+}

--- a/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/generated/model_connection_technology.go
+++ b/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/generated/model_connection_technology.go
@@ -1,0 +1,60 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// ConnectionTechnology is an enum. The connection technology is either the technology value of the related data source or the integration type
+type ConnectionTechnology string
+
+// Validate implements basic validation for this model
+func (m ConnectionTechnology) Validate() error {
+	return InKnownConnectionTechnology.Validate(m)
+}
+
+var (
+	ConnectionTechnologyGeneric    ConnectionTechnology = "generic"
+	ConnectionTechnologyMssql      ConnectionTechnology = "mssql"
+	ConnectionTechnologyMysql      ConnectionTechnology = "mysql"
+	ConnectionTechnologyOracle     ConnectionTechnology = "oracle"
+	ConnectionTechnologyOther      ConnectionTechnology = "other"
+	ConnectionTechnologyPostgresql ConnectionTechnology = "postgresql"
+	ConnectionTechnologyTableau    ConnectionTechnology = "tableau"
+
+	// KnownConnectionTechnology is the list of valid ConnectionTechnology
+	KnownConnectionTechnology = []ConnectionTechnology{
+		ConnectionTechnologyGeneric,
+		ConnectionTechnologyMssql,
+		ConnectionTechnologyMysql,
+		ConnectionTechnologyOracle,
+		ConnectionTechnologyOther,
+		ConnectionTechnologyPostgresql,
+		ConnectionTechnologyTableau,
+	}
+	// KnownConnectionTechnologyString is the list of valid ConnectionTechnology as string
+	KnownConnectionTechnologyString = []string{
+		string(ConnectionTechnologyGeneric),
+		string(ConnectionTechnologyMssql),
+		string(ConnectionTechnologyMysql),
+		string(ConnectionTechnologyOracle),
+		string(ConnectionTechnologyOther),
+		string(ConnectionTechnologyPostgresql),
+		string(ConnectionTechnologyTableau),
+	}
+
+	// InKnownConnectionTechnology is an ozzo-validator for ConnectionTechnology
+	InKnownConnectionTechnology = validation.In(
+		ConnectionTechnologyGeneric,
+		ConnectionTechnologyMssql,
+		ConnectionTechnologyMysql,
+		ConnectionTechnologyOracle,
+		ConnectionTechnologyOther,
+		ConnectionTechnologyPostgresql,
+		ConnectionTechnologyTableau,
+	)
+)

--- a/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/generated/model_data_source_technology.go
+++ b/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/generated/model_data_source_technology.go
@@ -1,0 +1,52 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// DataSourceTechnology is an enum. Technology of a data source. For external data sources this also specifies the type of connection (driver) being used to connect to the data source. Generic data sources may use any technology value (but no connection will be established). Generic data sources may also use the value "other" for technology in case no technology should be shown in the catalog or the technology is not known to the catalog.
+type DataSourceTechnology string
+
+// Validate implements basic validation for this model
+func (m DataSourceTechnology) Validate() error {
+	return InKnownDataSourceTechnology.Validate(m)
+}
+
+var (
+	DataSourceTechnologyMssql      DataSourceTechnology = "mssql"
+	DataSourceTechnologyMysql      DataSourceTechnology = "mysql"
+	DataSourceTechnologyOracle     DataSourceTechnology = "oracle"
+	DataSourceTechnologyOther      DataSourceTechnology = "other"
+	DataSourceTechnologyPostgresql DataSourceTechnology = "postgresql"
+
+	// KnownDataSourceTechnology is the list of valid DataSourceTechnology
+	KnownDataSourceTechnology = []DataSourceTechnology{
+		DataSourceTechnologyMssql,
+		DataSourceTechnologyMysql,
+		DataSourceTechnologyOracle,
+		DataSourceTechnologyOther,
+		DataSourceTechnologyPostgresql,
+	}
+	// KnownDataSourceTechnologyString is the list of valid DataSourceTechnology as string
+	KnownDataSourceTechnologyString = []string{
+		string(DataSourceTechnologyMssql),
+		string(DataSourceTechnologyMysql),
+		string(DataSourceTechnologyOracle),
+		string(DataSourceTechnologyOther),
+		string(DataSourceTechnologyPostgresql),
+	}
+
+	// InKnownDataSourceTechnology is an ozzo-validator for DataSourceTechnology
+	InKnownDataSourceTechnology = validation.In(
+		DataSourceTechnologyMssql,
+		DataSourceTechnologyMysql,
+		DataSourceTechnologyOracle,
+		DataSourceTechnologyOther,
+		DataSourceTechnologyPostgresql,
+	)
+)

--- a/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/generated/model_integration_type.go
+++ b/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/generated/model_integration_type.go
@@ -1,0 +1,40 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//     Title: Test
+//     Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// IntegrationType is an enum.
+type IntegrationType string
+
+// Validate implements basic validation for this model
+func (m IntegrationType) Validate() error {
+	return InKnownIntegrationType.Validate(m)
+}
+
+var (
+	IntegrationTypeGeneric IntegrationType = "generic"
+	IntegrationTypeTableau IntegrationType = "tableau"
+
+	// KnownIntegrationType is the list of valid IntegrationType
+	KnownIntegrationType = []IntegrationType{
+		IntegrationTypeGeneric,
+		IntegrationTypeTableau,
+	}
+	// KnownIntegrationTypeString is the list of valid IntegrationType as string
+	KnownIntegrationTypeString = []string{
+		string(IntegrationTypeGeneric),
+		string(IntegrationTypeTableau),
+	}
+
+	// InKnownIntegrationType is an ozzo-validator for IntegrationType
+	InKnownIntegrationType = validation.In(
+		IntegrationTypeGeneric,
+		IntegrationTypeTableau,
+	)
+)

--- a/pkg/generators/models/testdata/cases/embedded_type/expected/model_top.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/expected/model_top.go
@@ -14,7 +14,7 @@ type Top struct {
 	// Arr:
 	Arr []Sub1 `json:"arr,omitempty"`
 	// Boo: Type alias for a value type
-	Boo bool `json:"boo,omitempty"`
+	Boo Sub3 `json:"boo,omitempty"`
 	// Obj:
 	Obj Sub1 `json:"obj,omitempty"`
 }
@@ -24,6 +24,9 @@ func (m Top) Validate() error {
 	return validation.Errors{
 		"arr": validation.Validate(
 			m.Arr,
+		),
+		"boo": validation.Validate(
+			m.Boo,
 		),
 		"obj": validation.Validate(
 			m.Obj,
@@ -42,12 +45,12 @@ func (m *Top) SetArr(val []Sub1) {
 }
 
 // GetBoo returns the Boo property
-func (m Top) GetBoo() bool {
+func (m Top) GetBoo() Sub3 {
 	return m.Boo
 }
 
 // SetBoo sets the Boo property
-func (m *Top) SetBoo(val bool) {
+func (m *Top) SetBoo(val Sub3) {
 	m.Boo = val
 }
 

--- a/pkg/generators/models/testdata/cases/embedded_type/generated/model_top.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/generated/model_top.go
@@ -14,7 +14,7 @@ type Top struct {
 	// Arr:
 	Arr []Sub1 `json:"arr,omitempty"`
 	// Boo: Type alias for a value type
-	Boo bool `json:"boo,omitempty"`
+	Boo Sub3 `json:"boo,omitempty"`
 	// Obj:
 	Obj Sub1 `json:"obj,omitempty"`
 }
@@ -24,6 +24,9 @@ func (m Top) Validate() error {
 	return validation.Errors{
 		"arr": validation.Validate(
 			m.Arr,
+		),
+		"boo": validation.Validate(
+			m.Boo,
 		),
 		"obj": validation.Validate(
 			m.Obj,
@@ -42,12 +45,12 @@ func (m *Top) SetArr(val []Sub1) {
 }
 
 // GetBoo returns the Boo property
-func (m Top) GetBoo() bool {
+func (m Top) GetBoo() Sub3 {
 	return m.Boo
 }
 
 // SetBoo sets the Boo property
-func (m *Top) SetBoo(val bool) {
+func (m *Top) SetBoo(val Sub3) {
 	m.Boo = val
 }
 

--- a/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/expected/check.go
+++ b/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/expected/check.go
@@ -1,0 +1,11 @@
+package generatortest
+
+func check() bool {
+
+	foo := Error{}
+	switch foo.Discriminator() {
+	case ErrorDiscriminatorAuth:
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Improve the generation stability by sorting the models prior to
generating the models. This ensures that we always visit the models in
the same order, which is important because we are iterating over a map
of pointers, which can potentially mutate as we iterate through the
models.

This change makes the codegen deterministic, but is probalby the wrong
order to visit the models in. In a future release, we should consider
some kind of tree structure to ensure we visit in a consistent and
correct order.

fix: always prefer named models as struct props, except for slices

This change ensures that we return ref names instead of resolved
primitive types if a model has a field that references another model.
With one exception, when the field is a slice, we prefer to resolve the
model so that we avoid models that are slice aliases.

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>


<!-- Summary of changes above here -->

## Ticket
<!-- Paste the url for the jira task/bug or Github issue here -->
None, discovered when a CI flow started failing in another project. 

## How Has This Been Verified?
<!--- Please describe in detail how you tested your changes. -->
A new unit test has been added that covers the case that was failing in our CI. I have also extended the local development test case to run in a loop, to help ensure that the generation is consistent. This test now passes locally.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [ ] New code can be debugged via logs.
- [x] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
