### PR TITLE
feat: add HTTP HEAD operation

### DIFF
--- a/pkg/generators/router/head_operation_test.go
+++ b/pkg/generators/router/head_operation_test.go
@@ -1,0 +1,49 @@
+package router
+
+import (
+	"bufio"
+	"bytes"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeadOperation(t *testing.T) {
+	t.Run("generated file as expected", func(t *testing.T) {
+		basePath := "testdata/head_operation"
+		genDir := filepath.Join(basePath, "generated")
+		err := os.RemoveAll(genDir)
+		require.NoError(t, err)
+
+		err = os.MkdirAll(genDir, 0755)
+		require.NoError(t, err)
+		bs, err := ioutil.ReadFile(filepath.Join(basePath, "api.yaml"))
+		require.NoError(t, err)
+		reader := bytes.NewReader(bs)
+
+		outFile, err := os.Create(filepath.Join(genDir, "router.go"))
+		require.NoError(t, err)
+		defer outFile.Close()
+
+		writer := bufio.NewWriter(outFile)
+		err = Generate(reader, writer, Options{})
+		require.NoError(t, err)
+		writer.Flush()
+
+		outFile.Close()
+
+		equalFiles(t, filepath.Join(genDir, "router.go"), filepath.Join(basePath, "expected", "router.go"))
+	})
+}
+
+func equalFiles(t *testing.T, actual, expected string) {
+	bs1, err := ioutil.ReadFile(expected)
+	require.NoError(t, err)
+	bs2, err := ioutil.ReadFile(actual)
+	require.NoError(t, err)
+	require.Equal(t, string(bs1), string(bs2))
+}

--- a/pkg/generators/router/head_operation_test.go
+++ b/pkg/generators/router/head_operation_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 

--- a/pkg/generators/router/router.go
+++ b/pkg/generators/router/router.go
@@ -112,6 +112,7 @@ type path struct {
 	PUT    *endpoint `yaml:"put"`
 	PATCH  *endpoint `yaml:"patch"`
 	DELETE *endpoint `yaml:"delete"`
+	HEAD   *endpoint `yaml:"head"`
 }
 
 type info struct {
@@ -163,6 +164,13 @@ func createTemplateCtx(spec spec, opts Options) (out templateCtx, err error) {
 
 		if definition.DELETE != nil {
 			err = setEndpoint(&out, opts, http.MethodDelete, path, *definition.DELETE)
+			if err != nil {
+				return out, err
+			}
+		}
+
+		if definition.HEAD != nil {
+			err = setEndpoint(&out, opts, http.MethodHead, path, *definition.HEAD)
 			if err != nil {
 				return out, err
 			}

--- a/pkg/generators/router/testdata/head_operation/api.yaml
+++ b/pkg/generators/router/testdata/head_operation/api.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.0
+
+paths:
+  "/a/path":
+    head:
+      x-handler-group: HeadHandler
+      operationId: HeadOp
+      responses:
+        "200":
+          description: A response
+

--- a/pkg/generators/router/testdata/head_operation/expected/router.go
+++ b/pkg/generators/router/testdata/head_operation/expected/router.go
@@ -1,0 +1,46 @@
+package openapi
+
+// This file is auto-generated, don't modify it manually
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi"
+)
+
+// HeadHandlerHandler handles the operations of the 'HeadHandler' handler group.
+type HeadHandlerHandler interface {
+	// HeadOp
+	HeadOp(w http.ResponseWriter, r *http.Request)
+}
+
+// NewRouter creates a new router for the spec and the given handlers.
+//
+//
+//
+//
+//
+//
+func NewRouter(
+	headHandlerHandler HeadHandlerHandler,
+) http.Handler {
+
+	r := chi.NewRouter()
+
+	// 'HeadHandler' group
+
+	// '/a/path'
+	r.Options("/a/path", optionsHandlerFunc(
+		http.MethodHead,
+	))
+	r.Head("/a/path", headHandlerHandler.HeadOp)
+
+	return r
+}
+
+func optionsHandlerFunc(allowedMethods ...string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Allow", strings.Join(allowedMethods, ", "))
+	}
+}

--- a/pkg/generators/router/testdata/head_operation/generated/router.go
+++ b/pkg/generators/router/testdata/head_operation/generated/router.go
@@ -1,0 +1,46 @@
+package openapi
+
+// This file is auto-generated, don't modify it manually
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi"
+)
+
+// HeadHandlerHandler handles the operations of the 'HeadHandler' handler group.
+type HeadHandlerHandler interface {
+	// HeadOp
+	HeadOp(w http.ResponseWriter, r *http.Request)
+}
+
+// NewRouter creates a new router for the spec and the given handlers.
+//
+//
+//
+//
+//
+//
+func NewRouter(
+	headHandlerHandler HeadHandlerHandler,
+) http.Handler {
+
+	r := chi.NewRouter()
+
+	// 'HeadHandler' group
+
+	// '/a/path'
+	r.Options("/a/path", optionsHandlerFunc(
+		http.MethodHead,
+	))
+	r.Head("/a/path", headHandlerHandler.HeadOp)
+
+	return r
+}
+
+func optionsHandlerFunc(allowedMethods ...string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Allow", strings.Join(allowedMethods, ", "))
+	}
+}


### PR DESCRIPTION
This PR adds support for HEAD operations.

## How Has This Been Verified?

A test has been added that generates code from a simple `api.yaml` that contains a HEAD operation on a path and compares it to the expected result.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [ ] New code can be debugged via logs.
- [x] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
