### PR TITLE
feat: combined properties, additional properties in named objects

### DIFF
--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -90,6 +90,8 @@ type ConvertSpec struct {
 type PropSpec struct {
 	// Name is a property name in structs, variable name in enums, etc
 	Name string
+	// PropertyName is the original name of the property
+	PropertyName string
 	// Description used in the comment of the property
 	Description string
 	// GoType used for this property (e.g. `string`, `int`, etc)
@@ -506,12 +508,13 @@ func structPropsFromRef(ref *openapi3.SchemaRef) (specs []PropSpec, imports []st
 		prop = resolveAllOf(prop, nil)
 
 		spec := PropSpec{
-			Name:        tpl.ToPascalCase(name),
-			Description: prop.Value.Description,
-			GoType:      goTypeFromSpec(prop),
-			IsRequired:  checkIfRequired(name, ref.Value.Required),
-			IsEnum:      len(prop.Value.Enum) > 0,
-			IsNullable:  prop.Value.Nullable,
+			Name:         tpl.ToPascalCase(name),
+			PropertyName: name,
+			Description:  prop.Value.Description,
+			GoType:       goTypeFromSpec(prop),
+			IsRequired:   checkIfRequired(name, ref.Value.Required),
+			IsEnum:       len(prop.Value.Enum) > 0,
+			IsNullable:   prop.Value.Nullable,
 		}
 
 		if spec.GoType == "time.Time" || spec.GoType == "*time.Time" {

--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -75,6 +75,9 @@ type Model struct {
 	SpecVersion string
 	// PackageName is the name of the package used in the Go code
 	PackageName string
+	// AdditionalPropertiesGoType is the optional type of additional properties
+	// that exist _in addition_ to `Properties`
+	AdditionalPropertiesGoType string
 }
 
 // ConvertSpec holds all info to build one As{Type}() function
@@ -154,6 +157,8 @@ func NewModelFromRef(ref *openapi3.SchemaRef) (model *Model, err error) {
 			if ref.Value.AdditionalProperties != nil {
 				model.GoType = "map[string]" + goTypeFromSpec(ref.Value.AdditionalProperties)
 			}
+		} else if ref.Value.AdditionalProperties != nil || (ref.Value.AdditionalPropertiesAllowed != nil && *ref.Value.AdditionalPropertiesAllowed) {
+			model.AdditionalPropertiesGoType = goTypeFromSpec(ref.Value.AdditionalProperties)
 		}
 	case len(ref.Value.OneOf) > 0:
 		model.Kind = OneOf

--- a/pkg/generators/models/models_test.go
+++ b/pkg/generators/models/models_test.go
@@ -150,7 +150,11 @@ var cases = []struct {
 		name:      "example of nested allOf to create a merged enum with validation",
 		directory: "testdata/cases/allOf_enum_merging_and_validation",
 	},
-	// 29
+	{
+		name:      "example of objects with properties and additional properties",
+		directory: "testdata/cases/objects_with_properties_and_additional_properties",
+	},
+	// 30
 }
 
 func TestModels(t *testing.T) {

--- a/pkg/generators/models/templates/model.gotpl
+++ b/pkg/generators/models/templates/model.gotpl
@@ -68,7 +68,7 @@ func (obj *{{.Name}}) UnmarshalJSON(data []byte) error {
 	var additionalProperties = make(map[string]{{.AdditionalPropertiesGoType}})
 	for k, v := range generic {
 		{{- range .Properties}}
-		if k == "{{.Name}}" {
+		if k == "{{.PropertyName}}" {
 			if err := json.Unmarshal(v, &(obj.{{$.Name}}Properties.{{.Name}})); err != nil {
 				return err
 			}
@@ -103,7 +103,7 @@ func (obj {{.Name}}) MarshalJSON() ([]byte, error) {
 
 	{{- range .Properties}}
 	if propData, err := json.Marshal(obj.{{$.Name}}Properties.{{.Name}}); err == nil {
-		props["{{.Name}}"] = propData
+		props["{{.PropertyName}}"] = propData
 	} else {
 		return nil, err
 	}

--- a/pkg/generators/models/templates/model.gotpl
+++ b/pkg/generators/models/templates/model.gotpl
@@ -7,6 +7,10 @@
 package {{ .PackageName }}
 
 import (
+	{{- if .AdditionalPropertiesGoType}}
+	"encoding/json"
+	{{- end}}
+
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 {{- range .Imports}}
 	"{{.}}"
@@ -27,6 +31,7 @@ var {{ $modelName | firstLower }}{{.Name}}Pattern = regexp.MustCompile(`{{ .Patt
 {{- end}}
 
 {{ (printf "%s is an object. %s" .Name .Description) | commentBlock }}
+{{- if not .AdditionalPropertiesGoType }}
 {{- if not .Properties }}
 type {{.Name}} {{ .GoType }}
 {{- else }}
@@ -37,10 +42,84 @@ type {{.Name}} struct {
 {{- end}}
 }
 {{- end}}
+{{- else }}
+type {{.Name}} struct {
+	{{.Name}}Properties
+	AdditionalProperties map[string]{{.AdditionalPropertiesGoType}}
+}
 
+type {{.Name}}Properties struct {
+	{{- range .Properties}}
+	{{ (printf "%s: %s" .Name .Description) | commentBlock }}
+	{{.Name}} {{.GoType}} {{.JSONTags}}
+	{{- end}}
+}
 
+// Unmarshal all named properties into {{.Name}}Properties and
+// the rest into the AdditionalProperties map
+func (obj *{{.Name}}) UnmarshalJSON(data []byte) error {
+	var generic map[string]json.RawMessage
+	if err := json.Unmarshal(data, &generic); err != nil {
+		return err
+	}
+
+	obj.{{.Name}}Properties = {{.Name}}Properties{}
+
+	var additionalProperties = make(map[string]{{.AdditionalPropertiesGoType}})
+	for k, v := range generic {
+		{{- range .Properties}}
+		if k == "{{.Name}}" {
+			if err := json.Unmarshal(v, &(obj.{{$.Name}}Properties.{{.Name}})); err != nil {
+				return err
+			}
+			continue
+		}
+		{{- end}}
+		var prop {{.AdditionalPropertiesGoType}}
+		if err := json.Unmarshal(v, &prop); err != nil {
+			return err
+		}
+		additionalProperties[k] = prop
+	}
+
+	obj.AdditionalProperties = additionalProperties
+	return nil
+}
+
+// Marshal {{.Name}} by combining the AdditionalProperties with the
+// named properties in a single JSON object. Named properties take
+// precedence.
+func (obj {{.Name}}) MarshalJSON() ([]byte, error) {
+	props := make(map[string]json.RawMessage)
+
+	// start with additional properties so regular properties overwrite them
+	for k, v := range obj.AdditionalProperties {
+		if propData, err := json.Marshal(v); err == nil {
+			props[k] = propData
+		} else {
+			return nil, err
+		}
+	}
+
+	{{- range .Properties}}
+	if propData, err := json.Marshal(obj.{{$.Name}}Properties.{{.Name}}); err == nil {
+		props["{{.Name}}"] = propData
+	} else {
+		return nil, err
+	}
+	{{- end}}
+
+	data, err := json.Marshal(props)
+	return data, err
+}
+{{- end }}
+
+{{- $modelPropertiesName := $modelName }}
+{{- if .AdditionalPropertiesGoType }}
+  {{- $modelPropertiesName := print $modelName "Properties" }}
+{{- end }}
 // Validate implements basic validation for this model
-func (m {{$modelName}}) Validate() error {
+func (m {{$modelPropertiesName}}) Validate() error {
 	return validation.Errors{
 		{{- range .Properties}}
 			{{- if .NeedsValidation }}
@@ -72,12 +151,21 @@ func (m {{$modelName}}) Validate() error {
 }
 {{ range .Properties}}
 // Get{{.Name}} returns the {{.Name}} property
-func (m {{$modelName}}) Get{{.Name}}() {{.GoType}} {
+func (m {{$modelPropertiesName}}) Get{{.Name}}() {{.GoType}} {
 	return m.{{.Name}}
 }
 
 // Set{{.Name}} sets the {{.Name}} property
-func (m *{{$modelName}}) Set{{.Name}}(val {{.GoType}}) {
+func (m *{{$modelPropertiesName}}) Set{{.Name}}(val {{.GoType}}) {
 	m.{{.Name}} = val
 }
 {{ end}}
+{{- if .AdditionalPropertiesGoType }}
+func (m *{{$modelName}}) GetAdditionalProperties() map[string]{{.AdditionalPropertiesGoType}} {
+	return m.AdditionalProperties
+}
+
+func (m *{{$modelName}}) SetAdditionalProperties(val map[string]{{.AdditionalPropertiesGoType}}) {
+	m.AdditionalProperties = val
+}
+{{- end }}

--- a/pkg/generators/models/testdata/cases/objects_with_properties_and_additional_properties/api.yaml
+++ b/pkg/generators/models/testdata/cases/objects_with_properties_and_additional_properties/api.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.0
+info:
+  version: 0.1.0
+  title: Test
+
+components:
+  schemas:
+    Foo:
+      type: object
+      properties:
+        bar:
+          type: integer
+      requiredProperties:
+        - bar
+      additionalProperties: true
+    FooBar:
+      type: object
+      properties:
+        baz:
+          type: string
+      additionalProperties:
+        type: array
+        items:
+          type: object
+          properties:
+            test:
+              type: string

--- a/pkg/generators/models/testdata/cases/objects_with_properties_and_additional_properties/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/objects_with_properties_and_additional_properties/expected/model_foo.go
@@ -1,0 +1,100 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	"encoding/json"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Foo is an object.
+type Foo struct {
+	FooProperties
+	AdditionalProperties map[string]interface{}
+}
+
+type FooProperties struct {
+	// Bar:
+	Bar int32 `json:"bar,omitempty"`
+}
+
+// Unmarshal all named properties into FooProperties and
+// the rest into the AdditionalProperties map
+func (obj *Foo) UnmarshalJSON(data []byte) error {
+	var generic map[string]json.RawMessage
+	if err := json.Unmarshal(data, &generic); err != nil {
+		return err
+	}
+
+	obj.FooProperties = FooProperties{}
+
+	var additionalProperties = make(map[string]interface{})
+	for k, v := range generic {
+		if k == "Bar" {
+			if err := json.Unmarshal(v, &(obj.FooProperties.Bar)); err != nil {
+				return err
+			}
+			continue
+		}
+		var prop interface{}
+		if err := json.Unmarshal(v, &prop); err != nil {
+			return err
+		}
+		additionalProperties[k] = prop
+	}
+
+	obj.AdditionalProperties = additionalProperties
+	return nil
+}
+
+// Marshal Foo by combining the AdditionalProperties with the
+// named properties in a single JSON object. Named properties take
+// precedence.
+func (obj Foo) MarshalJSON() ([]byte, error) {
+	props := make(map[string]json.RawMessage)
+
+	// start with additional properties so regular properties overwrite them
+	for k, v := range obj.AdditionalProperties {
+		if propData, err := json.Marshal(v); err == nil {
+			props[k] = propData
+		} else {
+			return nil, err
+		}
+	}
+	if propData, err := json.Marshal(obj.FooProperties.Bar); err == nil {
+		props["Bar"] = propData
+	} else {
+		return nil, err
+	}
+
+	data, err := json.Marshal(props)
+	return data, err
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{}.Filter()
+}
+
+// GetBar returns the Bar property
+func (m Foo) GetBar() int32 {
+	return m.Bar
+}
+
+// SetBar sets the Bar property
+func (m *Foo) SetBar(val int32) {
+	m.Bar = val
+}
+
+func (m *Foo) GetAdditionalProperties() map[string]interface{} {
+	return m.AdditionalProperties
+}
+
+func (m *Foo) SetAdditionalProperties(val map[string]interface{}) {
+	m.AdditionalProperties = val
+}

--- a/pkg/generators/models/testdata/cases/objects_with_properties_and_additional_properties/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/objects_with_properties_and_additional_properties/expected/model_foo.go
@@ -35,7 +35,7 @@ func (obj *Foo) UnmarshalJSON(data []byte) error {
 
 	var additionalProperties = make(map[string]interface{})
 	for k, v := range generic {
-		if k == "Bar" {
+		if k == "bar" {
 			if err := json.Unmarshal(v, &(obj.FooProperties.Bar)); err != nil {
 				return err
 			}
@@ -67,7 +67,7 @@ func (obj Foo) MarshalJSON() ([]byte, error) {
 		}
 	}
 	if propData, err := json.Marshal(obj.FooProperties.Bar); err == nil {
-		props["Bar"] = propData
+		props["bar"] = propData
 	} else {
 		return nil, err
 	}

--- a/pkg/generators/models/testdata/cases/objects_with_properties_and_additional_properties/expected/model_foo_bar.go
+++ b/pkg/generators/models/testdata/cases/objects_with_properties_and_additional_properties/expected/model_foo_bar.go
@@ -39,7 +39,7 @@ func (obj *FooBar) UnmarshalJSON(data []byte) error {
 		Test string `json:"test,omitempty"`
 	})
 	for k, v := range generic {
-		if k == "Baz" {
+		if k == "baz" {
 			if err := json.Unmarshal(v, &(obj.FooBarProperties.Baz)); err != nil {
 				return err
 			}
@@ -73,7 +73,7 @@ func (obj FooBar) MarshalJSON() ([]byte, error) {
 		}
 	}
 	if propData, err := json.Marshal(obj.FooBarProperties.Baz); err == nil {
-		props["Baz"] = propData
+		props["baz"] = propData
 	} else {
 		return nil, err
 	}

--- a/pkg/generators/models/testdata/cases/objects_with_properties_and_additional_properties/expected/model_foo_bar.go
+++ b/pkg/generators/models/testdata/cases/objects_with_properties_and_additional_properties/expected/model_foo_bar.go
@@ -1,0 +1,110 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	"encoding/json"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// FooBar is an object.
+type FooBar struct {
+	FooBarProperties
+	AdditionalProperties map[string][]struct {
+		Test string `json:"test,omitempty"`
+	}
+}
+
+type FooBarProperties struct {
+	// Baz:
+	Baz string `json:"baz,omitempty"`
+}
+
+// Unmarshal all named properties into FooBarProperties and
+// the rest into the AdditionalProperties map
+func (obj *FooBar) UnmarshalJSON(data []byte) error {
+	var generic map[string]json.RawMessage
+	if err := json.Unmarshal(data, &generic); err != nil {
+		return err
+	}
+
+	obj.FooBarProperties = FooBarProperties{}
+
+	var additionalProperties = make(map[string][]struct {
+		Test string `json:"test,omitempty"`
+	})
+	for k, v := range generic {
+		if k == "Baz" {
+			if err := json.Unmarshal(v, &(obj.FooBarProperties.Baz)); err != nil {
+				return err
+			}
+			continue
+		}
+		var prop []struct {
+			Test string `json:"test,omitempty"`
+		}
+		if err := json.Unmarshal(v, &prop); err != nil {
+			return err
+		}
+		additionalProperties[k] = prop
+	}
+
+	obj.AdditionalProperties = additionalProperties
+	return nil
+}
+
+// Marshal FooBar by combining the AdditionalProperties with the
+// named properties in a single JSON object. Named properties take
+// precedence.
+func (obj FooBar) MarshalJSON() ([]byte, error) {
+	props := make(map[string]json.RawMessage)
+
+	// start with additional properties so regular properties overwrite them
+	for k, v := range obj.AdditionalProperties {
+		if propData, err := json.Marshal(v); err == nil {
+			props[k] = propData
+		} else {
+			return nil, err
+		}
+	}
+	if propData, err := json.Marshal(obj.FooBarProperties.Baz); err == nil {
+		props["Baz"] = propData
+	} else {
+		return nil, err
+	}
+
+	data, err := json.Marshal(props)
+	return data, err
+}
+
+// Validate implements basic validation for this model
+func (m FooBar) Validate() error {
+	return validation.Errors{}.Filter()
+}
+
+// GetBaz returns the Baz property
+func (m FooBar) GetBaz() string {
+	return m.Baz
+}
+
+// SetBaz sets the Baz property
+func (m *FooBar) SetBaz(val string) {
+	m.Baz = val
+}
+
+func (m *FooBar) GetAdditionalProperties() map[string][]struct {
+	Test string `json:"test,omitempty"`
+} {
+	return m.AdditionalProperties
+}
+
+func (m *FooBar) SetAdditionalProperties(val map[string][]struct {
+	Test string `json:"test,omitempty"`
+}) {
+	m.AdditionalProperties = val
+}

--- a/pkg/generators/models/testdata/cases/objects_with_properties_and_additional_properties/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/objects_with_properties_and_additional_properties/generated/model_foo.go
@@ -1,0 +1,100 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	"encoding/json"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Foo is an object.
+type Foo struct {
+	FooProperties
+	AdditionalProperties map[string]interface{}
+}
+
+type FooProperties struct {
+	// Bar:
+	Bar int32 `json:"bar,omitempty"`
+}
+
+// Unmarshal all named properties into FooProperties and
+// the rest into the AdditionalProperties map
+func (obj *Foo) UnmarshalJSON(data []byte) error {
+	var generic map[string]json.RawMessage
+	if err := json.Unmarshal(data, &generic); err != nil {
+		return err
+	}
+
+	obj.FooProperties = FooProperties{}
+
+	var additionalProperties = make(map[string]interface{})
+	for k, v := range generic {
+		if k == "Bar" {
+			if err := json.Unmarshal(v, &(obj.FooProperties.Bar)); err != nil {
+				return err
+			}
+			continue
+		}
+		var prop interface{}
+		if err := json.Unmarshal(v, &prop); err != nil {
+			return err
+		}
+		additionalProperties[k] = prop
+	}
+
+	obj.AdditionalProperties = additionalProperties
+	return nil
+}
+
+// Marshal Foo by combining the AdditionalProperties with the
+// named properties in a single JSON object. Named properties take
+// precedence.
+func (obj Foo) MarshalJSON() ([]byte, error) {
+	props := make(map[string]json.RawMessage)
+
+	// start with additional properties so regular properties overwrite them
+	for k, v := range obj.AdditionalProperties {
+		if propData, err := json.Marshal(v); err == nil {
+			props[k] = propData
+		} else {
+			return nil, err
+		}
+	}
+	if propData, err := json.Marshal(obj.FooProperties.Bar); err == nil {
+		props["Bar"] = propData
+	} else {
+		return nil, err
+	}
+
+	data, err := json.Marshal(props)
+	return data, err
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{}.Filter()
+}
+
+// GetBar returns the Bar property
+func (m Foo) GetBar() int32 {
+	return m.Bar
+}
+
+// SetBar sets the Bar property
+func (m *Foo) SetBar(val int32) {
+	m.Bar = val
+}
+
+func (m *Foo) GetAdditionalProperties() map[string]interface{} {
+	return m.AdditionalProperties
+}
+
+func (m *Foo) SetAdditionalProperties(val map[string]interface{}) {
+	m.AdditionalProperties = val
+}

--- a/pkg/generators/models/testdata/cases/objects_with_properties_and_additional_properties/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/objects_with_properties_and_additional_properties/generated/model_foo.go
@@ -35,7 +35,7 @@ func (obj *Foo) UnmarshalJSON(data []byte) error {
 
 	var additionalProperties = make(map[string]interface{})
 	for k, v := range generic {
-		if k == "Bar" {
+		if k == "bar" {
 			if err := json.Unmarshal(v, &(obj.FooProperties.Bar)); err != nil {
 				return err
 			}
@@ -67,7 +67,7 @@ func (obj Foo) MarshalJSON() ([]byte, error) {
 		}
 	}
 	if propData, err := json.Marshal(obj.FooProperties.Bar); err == nil {
-		props["Bar"] = propData
+		props["bar"] = propData
 	} else {
 		return nil, err
 	}

--- a/pkg/generators/models/testdata/cases/objects_with_properties_and_additional_properties/generated/model_foo_bar.go
+++ b/pkg/generators/models/testdata/cases/objects_with_properties_and_additional_properties/generated/model_foo_bar.go
@@ -39,7 +39,7 @@ func (obj *FooBar) UnmarshalJSON(data []byte) error {
 		Test string `json:"test,omitempty"`
 	})
 	for k, v := range generic {
-		if k == "Baz" {
+		if k == "baz" {
 			if err := json.Unmarshal(v, &(obj.FooBarProperties.Baz)); err != nil {
 				return err
 			}
@@ -73,7 +73,7 @@ func (obj FooBar) MarshalJSON() ([]byte, error) {
 		}
 	}
 	if propData, err := json.Marshal(obj.FooBarProperties.Baz); err == nil {
-		props["Baz"] = propData
+		props["baz"] = propData
 	} else {
 		return nil, err
 	}

--- a/pkg/generators/models/testdata/cases/objects_with_properties_and_additional_properties/generated/model_foo_bar.go
+++ b/pkg/generators/models/testdata/cases/objects_with_properties_and_additional_properties/generated/model_foo_bar.go
@@ -1,0 +1,110 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	"encoding/json"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// FooBar is an object.
+type FooBar struct {
+	FooBarProperties
+	AdditionalProperties map[string][]struct {
+		Test string `json:"test,omitempty"`
+	}
+}
+
+type FooBarProperties struct {
+	// Baz:
+	Baz string `json:"baz,omitempty"`
+}
+
+// Unmarshal all named properties into FooBarProperties and
+// the rest into the AdditionalProperties map
+func (obj *FooBar) UnmarshalJSON(data []byte) error {
+	var generic map[string]json.RawMessage
+	if err := json.Unmarshal(data, &generic); err != nil {
+		return err
+	}
+
+	obj.FooBarProperties = FooBarProperties{}
+
+	var additionalProperties = make(map[string][]struct {
+		Test string `json:"test,omitempty"`
+	})
+	for k, v := range generic {
+		if k == "Baz" {
+			if err := json.Unmarshal(v, &(obj.FooBarProperties.Baz)); err != nil {
+				return err
+			}
+			continue
+		}
+		var prop []struct {
+			Test string `json:"test,omitempty"`
+		}
+		if err := json.Unmarshal(v, &prop); err != nil {
+			return err
+		}
+		additionalProperties[k] = prop
+	}
+
+	obj.AdditionalProperties = additionalProperties
+	return nil
+}
+
+// Marshal FooBar by combining the AdditionalProperties with the
+// named properties in a single JSON object. Named properties take
+// precedence.
+func (obj FooBar) MarshalJSON() ([]byte, error) {
+	props := make(map[string]json.RawMessage)
+
+	// start with additional properties so regular properties overwrite them
+	for k, v := range obj.AdditionalProperties {
+		if propData, err := json.Marshal(v); err == nil {
+			props[k] = propData
+		} else {
+			return nil, err
+		}
+	}
+	if propData, err := json.Marshal(obj.FooBarProperties.Baz); err == nil {
+		props["Baz"] = propData
+	} else {
+		return nil, err
+	}
+
+	data, err := json.Marshal(props)
+	return data, err
+}
+
+// Validate implements basic validation for this model
+func (m FooBar) Validate() error {
+	return validation.Errors{}.Filter()
+}
+
+// GetBaz returns the Baz property
+func (m FooBar) GetBaz() string {
+	return m.Baz
+}
+
+// SetBaz sets the Baz property
+func (m *FooBar) SetBaz(val string) {
+	m.Baz = val
+}
+
+func (m *FooBar) GetAdditionalProperties() map[string][]struct {
+	Test string `json:"test,omitempty"`
+} {
+	return m.AdditionalProperties
+}
+
+func (m *FooBar) SetAdditionalProperties(val map[string][]struct {
+	Test string `json:"test,omitempty"`
+}) {
+	m.AdditionalProperties = val
+}


### PR DESCRIPTION
This PR introduces code generation for named schemas that have both named properties and additional properties. For such objects two structs are created:
- one struct containing the regular properties and
- one struct embedding the first one and providing a separate `AdditionalProperties` map

Additionally, custom marshaling and unmarshaling functions for the latter struct are generated.
<!-- Summary of changes above here -->

## Ticket
<!-- Paste the url for the jira task/bug or Github issue here -->

## How Has This Been Verified?
The code generation is verified with additional tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [ ] New code can be debugged via logs.
- [x] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [x] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
