### PR TITLE
fix: panic on oneof validation

### DIFF
--- a/pkg/generators/models/templates/oneof.gotpl
+++ b/pkg/generators/models/templates/oneof.gotpl
@@ -47,6 +47,9 @@ type {{$modelName}} struct {
 	{{- end }}
 }
 
+{{- if .Discriminator.Field }}
+var Empty{{$modelName}}Error = fmt.Errorf("empty data is not an {{$modelName}}")
+{{- end }}
 
 // MarshalJSON implements the json.Marshaller interface
 func (m {{$modelName}}) MarshalJSON() ([]byte, error) {
@@ -102,12 +105,22 @@ func (m *{{$modelName}}) From{{$convert.TargetGoType | typeDisplayName}}(data {{
 
 // As converts {{$modelName}} to a user defined structure.
 func (m {{$modelName}}) As(target interface{}) error {
+	{{- if .Discriminator.Field }}
+	if m.data == nil {
+		return Empty{{$modelName}}Error
+	}
+	{{- end }}
 	return mapstructure.Decode(m.data, target)
 }
 
 {{- range $convert := .ConvertSpecs }}
 // As{{firstUpper $convert.TargetGoType}} converts {{$modelName}} to a {{$convert.TargetGoType}}
 func (m {{$modelName}}) As{{$convert.TargetGoType | typeDisplayName }}() (result {{$convert.TargetGoType}}, err error) {
+	{{- if $.Discriminator.Field }}
+	if m.data == nil {
+		return result, Empty{{$modelName}}Error
+	}
+	{{- end }}
 	return result, mapstructure.Decode(m.data, &result)
 }
 {{- end}}
@@ -121,6 +134,11 @@ func (m {{$modelName}}) Discriminator() {{$modelName}}Discriminator {
 
 // Validate implements basic validation for this model
 func (m {{$modelName}}) Validate() error {
+	{{- if .Discriminator.Field }}
+	if m.data == nil {
+		return Empty{{$modelName}}Error
+	}
+	{{- end }}
 	discriminator := m.data.{{$modelName}}Discriminator()
 	switch discriminator {
 	{{- range $value, $type := .Discriminator.Map }}

--- a/pkg/generators/models/testdata/cases/nested_inline_arrays/expected/model_geometry.go
+++ b/pkg/generators/models/testdata/cases/nested_inline_arrays/expected/model_geometry.go
@@ -34,6 +34,8 @@ type Geometry struct {
 	data geometryer
 }
 
+var EmptyGeometryError = fmt.Errorf("empty data is not an Geometry")
+
 // MarshalJSON implements the json.Marshaller interface
 func (m Geometry) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.data)
@@ -91,16 +93,25 @@ func (m *Geometry) FromShape(data Shape) {
 
 // As converts Geometry to a user defined structure.
 func (m Geometry) As(target interface{}) error {
+	if m.data == nil {
+		return EmptyGeometryError
+	}
 	return mapstructure.Decode(m.data, target)
 }
 
 // AsLine converts Geometry to a Line
 func (m Geometry) AsLine() (result Line, err error) {
+	if m.data == nil {
+		return result, EmptyGeometryError
+	}
 	return result, mapstructure.Decode(m.data, &result)
 }
 
 // AsShape converts Geometry to a Shape
 func (m Geometry) AsShape() (result Shape, err error) {
+	if m.data == nil {
+		return result, EmptyGeometryError
+	}
 	return result, mapstructure.Decode(m.data, &result)
 }
 
@@ -111,6 +122,9 @@ func (m Geometry) Discriminator() GeometryDiscriminator {
 
 // Validate implements basic validation for this model
 func (m Geometry) Validate() error {
+	if m.data == nil {
+		return EmptyGeometryError
+	}
 	discriminator := m.data.GeometryDiscriminator()
 	switch discriminator {
 	case GeometryDiscriminatorLine:

--- a/pkg/generators/models/testdata/cases/nested_inline_arrays/generated/model_geometry.go
+++ b/pkg/generators/models/testdata/cases/nested_inline_arrays/generated/model_geometry.go
@@ -34,6 +34,8 @@ type Geometry struct {
 	data geometryer
 }
 
+var EmptyGeometryError = fmt.Errorf("empty data is not an Geometry")
+
 // MarshalJSON implements the json.Marshaller interface
 func (m Geometry) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.data)
@@ -91,16 +93,25 @@ func (m *Geometry) FromShape(data Shape) {
 
 // As converts Geometry to a user defined structure.
 func (m Geometry) As(target interface{}) error {
+	if m.data == nil {
+		return EmptyGeometryError
+	}
 	return mapstructure.Decode(m.data, target)
 }
 
 // AsLine converts Geometry to a Line
 func (m Geometry) AsLine() (result Line, err error) {
+	if m.data == nil {
+		return result, EmptyGeometryError
+	}
 	return result, mapstructure.Decode(m.data, &result)
 }
 
 // AsShape converts Geometry to a Shape
 func (m Geometry) AsShape() (result Shape, err error) {
+	if m.data == nil {
+		return result, EmptyGeometryError
+	}
 	return result, mapstructure.Decode(m.data, &result)
 }
 
@@ -111,6 +122,9 @@ func (m Geometry) Discriminator() GeometryDiscriminator {
 
 // Validate implements basic validation for this model
 func (m Geometry) Validate() error {
+	if m.data == nil {
+		return EmptyGeometryError
+	}
 	discriminator := m.data.GeometryDiscriminator()
 	switch discriminator {
 	case GeometryDiscriminatorLine:

--- a/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/api.yaml
+++ b/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/api.yaml
@@ -90,3 +90,9 @@ components:
           field: '#/components/schemas/FieldError'
           external: '#/components/schemas/ExternalError'
           auth: '#/components/schemas/GenericError'
+
+    Container:
+      type: object
+      properties:
+        error:
+          $ref: "#/components/schemas/Error"

--- a/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/expected/container_validation_test.go
+++ b/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/expected/container_validation_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,5 +16,7 @@ func TestContainerValidation(t *testing.T) {
 	require.NoError(t, err)
 
 	err = container.Validate()
-	require.NoError(t, err)
+	require.Equal(t, err, validation.Errors{
+		"error": EmptyErrorError,
+	})
 }

--- a/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/expected/container_validation_test.go
+++ b/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/expected/container_validation_test.go
@@ -1,0 +1,19 @@
+package generatortest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerValidation(t *testing.T) {
+	rawBytes := `{}`
+	var container Container
+
+	err := json.Unmarshal([]byte(rawBytes), &container)
+	require.NoError(t, err)
+
+	err = container.Validate()
+	require.NoError(t, err)
+}

--- a/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/expected/model_container.go
+++ b/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/expected/model_container.go
@@ -1,0 +1,36 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test oneOf discriminator support
+//	Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Container is an object.
+type Container struct {
+	// Error:
+	Error Error `json:"error,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Container) Validate() error {
+	return validation.Errors{
+		"error": validation.Validate(
+			m.Error,
+		),
+	}.Filter()
+}
+
+// GetError returns the Error property
+func (m Container) GetError() Error {
+	return m.Error
+}
+
+// SetError sets the Error property
+func (m *Container) SetError(val Error) {
+	m.Error = val
+}

--- a/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/expected/model_error.go
+++ b/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/expected/model_error.go
@@ -38,6 +38,8 @@ type Error struct {
 	data errorer
 }
 
+var EmptyErrorError = fmt.Errorf("empty data is not an Error")
+
 // MarshalJSON implements the json.Marshaller interface
 func (m Error) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.data)
@@ -114,21 +116,33 @@ func (m *Error) FromExternalError(data ExternalError) {
 
 // As converts Error to a user defined structure.
 func (m Error) As(target interface{}) error {
+	if m.data == nil {
+		return EmptyErrorError
+	}
 	return mapstructure.Decode(m.data, target)
 }
 
 // AsGenericError converts Error to a GenericError
 func (m Error) AsGenericError() (result GenericError, err error) {
+	if m.data == nil {
+		return result, EmptyErrorError
+	}
 	return result, mapstructure.Decode(m.data, &result)
 }
 
 // AsFieldError converts Error to a FieldError
 func (m Error) AsFieldError() (result FieldError, err error) {
+	if m.data == nil {
+		return result, EmptyErrorError
+	}
 	return result, mapstructure.Decode(m.data, &result)
 }
 
 // AsExternalError converts Error to a ExternalError
 func (m Error) AsExternalError() (result ExternalError, err error) {
+	if m.data == nil {
+		return result, EmptyErrorError
+	}
 	return result, mapstructure.Decode(m.data, &result)
 }
 
@@ -139,6 +153,9 @@ func (m Error) Discriminator() ErrorDiscriminator {
 
 // Validate implements basic validation for this model
 func (m Error) Validate() error {
+	if m.data == nil {
+		return EmptyErrorError
+	}
 	discriminator := m.data.ErrorDiscriminator()
 	switch discriminator {
 	case ErrorDiscriminatorAuth:

--- a/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/generated/model_container.go
+++ b/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/generated/model_container.go
@@ -1,0 +1,36 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test oneOf discriminator support
+//	Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Container is an object.
+type Container struct {
+	// Error:
+	Error Error `json:"error,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Container) Validate() error {
+	return validation.Errors{
+		"error": validation.Validate(
+			m.Error,
+		),
+	}.Filter()
+}
+
+// GetError returns the Error property
+func (m Container) GetError() Error {
+	return m.Error
+}
+
+// SetError sets the Error property
+func (m *Container) SetError(val Error) {
+	m.Error = val
+}

--- a/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/generated/model_error.go
+++ b/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/generated/model_error.go
@@ -38,6 +38,8 @@ type Error struct {
 	data errorer
 }
 
+var EmptyErrorError = fmt.Errorf("empty data is not an Error")
+
 // MarshalJSON implements the json.Marshaller interface
 func (m Error) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.data)
@@ -114,21 +116,33 @@ func (m *Error) FromExternalError(data ExternalError) {
 
 // As converts Error to a user defined structure.
 func (m Error) As(target interface{}) error {
+	if m.data == nil {
+		return EmptyErrorError
+	}
 	return mapstructure.Decode(m.data, target)
 }
 
 // AsGenericError converts Error to a GenericError
 func (m Error) AsGenericError() (result GenericError, err error) {
+	if m.data == nil {
+		return result, EmptyErrorError
+	}
 	return result, mapstructure.Decode(m.data, &result)
 }
 
 // AsFieldError converts Error to a FieldError
 func (m Error) AsFieldError() (result FieldError, err error) {
+	if m.data == nil {
+		return result, EmptyErrorError
+	}
 	return result, mapstructure.Decode(m.data, &result)
 }
 
 // AsExternalError converts Error to a ExternalError
 func (m Error) AsExternalError() (result ExternalError, err error) {
+	if m.data == nil {
+		return result, EmptyErrorError
+	}
 	return result, mapstructure.Decode(m.data, &result)
 }
 
@@ -139,6 +153,9 @@ func (m Error) Discriminator() ErrorDiscriminator {
 
 // Validate implements basic validation for this model
 func (m Error) Validate() error {
+	if m.data == nil {
+		return EmptyErrorError
+	}
 	discriminator := m.data.ErrorDiscriminator()
 	switch discriminator {
 	case ErrorDiscriminatorAuth:

--- a/pkg/generators/models/testdata/cases/oneof_unmapped_discriminator/expected/model_error.go
+++ b/pkg/generators/models/testdata/cases/oneof_unmapped_discriminator/expected/model_error.go
@@ -36,6 +36,8 @@ type Error struct {
 	data errorer
 }
 
+var EmptyErrorError = fmt.Errorf("empty data is not an Error")
+
 // MarshalJSON implements the json.Marshaller interface
 func (m Error) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.data)
@@ -105,21 +107,33 @@ func (m *Error) FromExternalError(data ExternalError) {
 
 // As converts Error to a user defined structure.
 func (m Error) As(target interface{}) error {
+	if m.data == nil {
+		return EmptyErrorError
+	}
 	return mapstructure.Decode(m.data, target)
 }
 
 // AsGenericError converts Error to a GenericError
 func (m Error) AsGenericError() (result GenericError, err error) {
+	if m.data == nil {
+		return result, EmptyErrorError
+	}
 	return result, mapstructure.Decode(m.data, &result)
 }
 
 // AsFieldError converts Error to a FieldError
 func (m Error) AsFieldError() (result FieldError, err error) {
+	if m.data == nil {
+		return result, EmptyErrorError
+	}
 	return result, mapstructure.Decode(m.data, &result)
 }
 
 // AsExternalError converts Error to a ExternalError
 func (m Error) AsExternalError() (result ExternalError, err error) {
+	if m.data == nil {
+		return result, EmptyErrorError
+	}
 	return result, mapstructure.Decode(m.data, &result)
 }
 
@@ -130,6 +144,9 @@ func (m Error) Discriminator() ErrorDiscriminator {
 
 // Validate implements basic validation for this model
 func (m Error) Validate() error {
+	if m.data == nil {
+		return EmptyErrorError
+	}
 	discriminator := m.data.ErrorDiscriminator()
 	switch discriminator {
 	case ErrorDiscriminatorExternalError:

--- a/pkg/generators/models/testdata/cases/oneof_unmapped_discriminator/generated/model_error.go
+++ b/pkg/generators/models/testdata/cases/oneof_unmapped_discriminator/generated/model_error.go
@@ -36,6 +36,8 @@ type Error struct {
 	data errorer
 }
 
+var EmptyErrorError = fmt.Errorf("empty data is not an Error")
+
 // MarshalJSON implements the json.Marshaller interface
 func (m Error) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.data)
@@ -105,21 +107,33 @@ func (m *Error) FromExternalError(data ExternalError) {
 
 // As converts Error to a user defined structure.
 func (m Error) As(target interface{}) error {
+	if m.data == nil {
+		return EmptyErrorError
+	}
 	return mapstructure.Decode(m.data, target)
 }
 
 // AsGenericError converts Error to a GenericError
 func (m Error) AsGenericError() (result GenericError, err error) {
+	if m.data == nil {
+		return result, EmptyErrorError
+	}
 	return result, mapstructure.Decode(m.data, &result)
 }
 
 // AsFieldError converts Error to a FieldError
 func (m Error) AsFieldError() (result FieldError, err error) {
+	if m.data == nil {
+		return result, EmptyErrorError
+	}
 	return result, mapstructure.Decode(m.data, &result)
 }
 
 // AsExternalError converts Error to a ExternalError
 func (m Error) AsExternalError() (result ExternalError, err error) {
+	if m.data == nil {
+		return result, EmptyErrorError
+	}
 	return result, mapstructure.Decode(m.data, &result)
 }
 
@@ -130,6 +144,9 @@ func (m Error) Discriminator() ErrorDiscriminator {
 
 // Validate implements basic validation for this model
 func (m Error) Validate() error {
+	if m.data == nil {
+		return EmptyErrorError
+	}
 	discriminator := m.data.ErrorDiscriminator()
 	switch discriminator {
 	case ErrorDiscriminatorExternalError:


### PR DESCRIPTION
The generated validation for `oneof` schemas produces an error, if used as a property in another object and left empty (e.g. by omitting that property from the json payload). The cause is a nil initialized interface in the implementation, that gets dereferenced.

This PR adds extra checks to make sure the `nil` interface is never dereferenced.
<!-- Summary of changes above here -->

## Ticket
<!-- Paste the url for the jira task/bug or Github issue here -->

## How Has This Been Verified?
<!--- Please describe in detail how you tested your changes. -->
A new test has been added to verify the expected behavior (a validation error is returned for missing `oneof` fields).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [ ] New code can be debugged via logs.
- [x] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
