### PR TITLE
feat!: Set pointers for non required not nullable objects

### DIFF
--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -516,10 +516,10 @@ func structPropsFromRef(ref *openapi3.SchemaRef) (specs []PropSpec, imports []st
 		isRequired := checkIfRequired(name, ref.Value.Required)
 		goType := goTypeFromSpec(prop)
 
-		// If a property is not required but also not nullable,
+		// If an object property is not required but also not nullable,
 		// it must be a pointer to allow it to either be fully specified or
 		// not present at all.
-		if !isRequired && !prop.Value.Nullable {
+		if !isRequired && !prop.Value.Nullable && len(prop.Value.Properties) > 0 {
 			goType = "*" + goType
 		}
 

--- a/pkg/generators/models/models_test.go
+++ b/pkg/generators/models/models_test.go
@@ -125,11 +125,11 @@ var cases = []struct {
 		name:      "allof merges required list",
 		directory: "testdata/cases/allof_merges_required_list",
 	},
+	// 25
 	{
 		name:      "allof merges enum list",
 		directory: "testdata/cases/allof_enum",
 	},
-	// 25
 	{
 		name:      "allof supports intermediate array types",
 		directory: "testdata/cases/allof_arrays",
@@ -146,6 +146,7 @@ var cases = []struct {
 		name:      "example of naming for nested inline arrays",
 		directory: "testdata/cases/nested_inline_arrays",
 	},
+	// 30
 	{
 		name:      "example of nested allOf to create a merged enum with validation",
 		directory: "testdata/cases/allOf_enum_merging_and_validation",
@@ -154,10 +155,13 @@ var cases = []struct {
 		name:      "example of objects with properties and additional properties",
 		directory: "testdata/cases/objects_with_properties_and_additional_properties",
 	},
-	// 30
 	{
 		name:      "example of model with snake case fields",
 		directory: "testdata/cases/snake_casing_handling",
+	},
+	{
+		name:      "example of object referencing other object that is not required and not nullable",
+		directory: "testdata/cases/not_required_not_nullable_object",
 	},
 }
 
@@ -212,7 +216,7 @@ func TestModels(t *testing.T) {
 func TestModelsSingleCase(t *testing.T) {
 	t.Skip("only used during local development")
 
-	tc := cases[32]
+	tc := cases[33]
 	count := 1
 	for i := 0; i < count; i++ {
 		t.Run(fmt.Sprintf("trial_%d_%s", i, tc.name), func(t *testing.T) {
@@ -233,7 +237,7 @@ func TestModelsSingleCase(t *testing.T) {
 			g, err := NewGenerator(reader, Options{
 				PackageName: "generatortest",
 				Destination: dir,
-				// Logger:      log.Logger.Output(zerolog.ConsoleWriter{Out: os.Stderr}),
+				//Logger:      log.Logger.Output(zerolog.ConsoleWriter{Out: os.Stderr}),
 				Logger: log.Output(io.Discard), // swap for debugging
 			})
 			require.NoError(t, err)

--- a/pkg/generators/models/testdata/cases/allof1/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof1/expected/model_foo.go
@@ -13,7 +13,7 @@ import (
 // Foo is an object.
 type Foo struct {
 	// Bar:
-	Bar struct {
+	Bar *struct {
 		Bar string `json:"bar,omitempty" mapstructure:"bar,omitempty"`
 		Foo string `json:"foo,omitempty" mapstructure:"foo,omitempty"`
 	} `json:"bar,omitempty" mapstructure:"bar,omitempty"`
@@ -25,7 +25,7 @@ func (m Foo) Validate() error {
 }
 
 // GetBar returns the Bar property
-func (m Foo) GetBar() struct {
+func (m Foo) GetBar() *struct {
 	Bar string `json:"bar,omitempty" mapstructure:"bar,omitempty"`
 	Foo string `json:"foo,omitempty" mapstructure:"foo,omitempty"`
 } {
@@ -33,7 +33,7 @@ func (m Foo) GetBar() struct {
 }
 
 // SetBar sets the Bar property
-func (m *Foo) SetBar(val struct {
+func (m *Foo) SetBar(val *struct {
 	Bar string `json:"bar,omitempty" mapstructure:"bar,omitempty"`
 	Foo string `json:"foo,omitempty" mapstructure:"foo,omitempty"`
 }) {

--- a/pkg/generators/models/testdata/cases/allof1/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/allof1/generated/model_foo.go
@@ -13,7 +13,7 @@ import (
 // Foo is an object.
 type Foo struct {
 	// Bar:
-	Bar struct {
+	Bar *struct {
 		Bar string `json:"bar,omitempty" mapstructure:"bar,omitempty"`
 		Foo string `json:"foo,omitempty" mapstructure:"foo,omitempty"`
 	} `json:"bar,omitempty" mapstructure:"bar,omitempty"`
@@ -25,7 +25,7 @@ func (m Foo) Validate() error {
 }
 
 // GetBar returns the Bar property
-func (m Foo) GetBar() struct {
+func (m Foo) GetBar() *struct {
 	Bar string `json:"bar,omitempty" mapstructure:"bar,omitempty"`
 	Foo string `json:"foo,omitempty" mapstructure:"foo,omitempty"`
 } {
@@ -33,7 +33,7 @@ func (m Foo) GetBar() struct {
 }
 
 // SetBar sets the Bar property
-func (m *Foo) SetBar(val struct {
+func (m *Foo) SetBar(val *struct {
 	Bar string `json:"bar,omitempty" mapstructure:"bar,omitempty"`
 	Foo string `json:"foo,omitempty" mapstructure:"foo,omitempty"`
 }) {

--- a/pkg/generators/models/testdata/cases/embedded_type/expected/model_top.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/expected/model_top.go
@@ -17,7 +17,7 @@ type Top struct {
 	// Boo: Type alias for a value type
 	Boo Sub3 `json:"boo,omitempty" mapstructure:"boo,omitempty"`
 	// Obj:
-	Obj Sub1 `json:"obj,omitempty" mapstructure:"obj,omitempty"`
+	Obj *Sub1 `json:"obj,omitempty" mapstructure:"obj,omitempty"`
 }
 
 // Validate implements basic validation for this model
@@ -56,11 +56,11 @@ func (m *Top) SetBoo(val Sub3) {
 }
 
 // GetObj returns the Obj property
-func (m Top) GetObj() Sub1 {
+func (m Top) GetObj() *Sub1 {
 	return m.Obj
 }
 
 // SetObj sets the Obj property
-func (m *Top) SetObj(val Sub1) {
+func (m *Top) SetObj(val *Sub1) {
 	m.Obj = val
 }

--- a/pkg/generators/models/testdata/cases/embedded_type/generated/model_top.go
+++ b/pkg/generators/models/testdata/cases/embedded_type/generated/model_top.go
@@ -17,7 +17,7 @@ type Top struct {
 	// Boo: Type alias for a value type
 	Boo Sub3 `json:"boo,omitempty" mapstructure:"boo,omitempty"`
 	// Obj:
-	Obj Sub1 `json:"obj,omitempty" mapstructure:"obj,omitempty"`
+	Obj *Sub1 `json:"obj,omitempty" mapstructure:"obj,omitempty"`
 }
 
 // Validate implements basic validation for this model
@@ -56,11 +56,11 @@ func (m *Top) SetBoo(val Sub3) {
 }
 
 // GetObj returns the Obj property
-func (m Top) GetObj() Sub1 {
+func (m Top) GetObj() *Sub1 {
 	return m.Obj
 }
 
 // SetObj sets the Obj property
-func (m *Top) SetObj(val Sub1) {
+func (m *Top) SetObj(val *Sub1) {
 	m.Obj = val
 }

--- a/pkg/generators/models/testdata/cases/not_required_not_nullable_object/api.yaml
+++ b/pkg/generators/models/testdata/cases/not_required_not_nullable_object/api.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.0
+info:
+  version: 0.1.0
+  title: Test
+
+components:
+  schemas:
+    Foo:
+      type: object
+      properties:
+        bar:
+          "$ref": "#/components/schemas/FooBar"
+    FooBar:
+      type: object
+      properties:
+        baz:
+          type: string
+      required:
+        - baz

--- a/pkg/generators/models/testdata/cases/not_required_not_nullable_object/expected/model_foo.go
+++ b/pkg/generators/models/testdata/cases/not_required_not_nullable_object/expected/model_foo.go
@@ -1,0 +1,36 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Foo is an object.
+type Foo struct {
+	// Bar:
+	Bar *FooBar `json:"bar,omitempty" mapstructure:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
+}
+
+// GetBar returns the Bar property
+func (m Foo) GetBar() *FooBar {
+	return m.Bar
+}
+
+// SetBar sets the Bar property
+func (m *Foo) SetBar(val *FooBar) {
+	m.Bar = val
+}

--- a/pkg/generators/models/testdata/cases/not_required_not_nullable_object/expected/model_foo_bar.go
+++ b/pkg/generators/models/testdata/cases/not_required_not_nullable_object/expected/model_foo_bar.go
@@ -1,0 +1,32 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// FooBar is an object.
+type FooBar struct {
+	// Baz:
+	Baz string `json:"baz" mapstructure:"baz"`
+}
+
+// Validate implements basic validation for this model
+func (m FooBar) Validate() error {
+	return validation.Errors{}.Filter()
+}
+
+// GetBaz returns the Baz property
+func (m FooBar) GetBaz() string {
+	return m.Baz
+}
+
+// SetBaz sets the Baz property
+func (m *FooBar) SetBaz(val string) {
+	m.Baz = val
+}

--- a/pkg/generators/models/testdata/cases/not_required_not_nullable_object/generated/model_foo.go
+++ b/pkg/generators/models/testdata/cases/not_required_not_nullable_object/generated/model_foo.go
@@ -1,0 +1,36 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// Foo is an object.
+type Foo struct {
+	// Bar:
+	Bar *FooBar `json:"bar,omitempty" mapstructure:"bar,omitempty"`
+}
+
+// Validate implements basic validation for this model
+func (m Foo) Validate() error {
+	return validation.Errors{
+		"bar": validation.Validate(
+			m.Bar,
+		),
+	}.Filter()
+}
+
+// GetBar returns the Bar property
+func (m Foo) GetBar() *FooBar {
+	return m.Bar
+}
+
+// SetBar sets the Bar property
+func (m *Foo) SetBar(val *FooBar) {
+	m.Bar = val
+}

--- a/pkg/generators/models/testdata/cases/not_required_not_nullable_object/generated/model_foo_bar.go
+++ b/pkg/generators/models/testdata/cases/not_required_not_nullable_object/generated/model_foo_bar.go
@@ -1,0 +1,32 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// FooBar is an object.
+type FooBar struct {
+	// Baz:
+	Baz string `json:"baz" mapstructure:"baz"`
+}
+
+// Validate implements basic validation for this model
+func (m FooBar) Validate() error {
+	return validation.Errors{}.Filter()
+}
+
+// GetBaz returns the Baz property
+func (m FooBar) GetBaz() string {
+	return m.Baz
+}
+
+// SetBaz sets the Baz property
+func (m *FooBar) SetBaz(val string) {
+	m.Baz = val
+}

--- a/pkg/generators/models/testdata/cases/validation/expected/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/expected/model_person.go
@@ -27,7 +27,7 @@ var personPomodoroPattern = regexp.MustCompile(`^\d{1,2}m$`)
 // Person is an object.
 type Person struct {
 	// Address:
-	Address Address `json:"address,omitempty" mapstructure:"address,omitempty"`
+	Address *Address `json:"address,omitempty" mapstructure:"address,omitempty"`
 	// Age:
 	Age float32 `json:"age,omitempty" mapstructure:"age,omitempty"`
 	// Base64:
@@ -129,12 +129,12 @@ func (m Person) Validate() error {
 }
 
 // GetAddress returns the Address property
-func (m Person) GetAddress() Address {
+func (m Person) GetAddress() *Address {
 	return m.Address
 }
 
 // SetAddress sets the Address property
-func (m *Person) SetAddress(val Address) {
+func (m *Person) SetAddress(val *Address) {
 	m.Address = val
 }
 

--- a/pkg/generators/models/testdata/cases/validation/generated/model_person.go
+++ b/pkg/generators/models/testdata/cases/validation/generated/model_person.go
@@ -27,7 +27,7 @@ var personPomodoroPattern = regexp.MustCompile(`^\d{1,2}m$`)
 // Person is an object.
 type Person struct {
 	// Address:
-	Address Address `json:"address,omitempty" mapstructure:"address,omitempty"`
+	Address *Address `json:"address,omitempty" mapstructure:"address,omitempty"`
 	// Age:
 	Age float32 `json:"age,omitempty" mapstructure:"age,omitempty"`
 	// Base64:
@@ -129,12 +129,12 @@ func (m Person) Validate() error {
 }
 
 // GetAddress returns the Address property
-func (m Person) GetAddress() Address {
+func (m Person) GetAddress() *Address {
 	return m.Address
 }
 
 // SetAddress sets the Address property
-func (m *Person) SetAddress(val Address) {
+func (m *Person) SetAddress(val *Address) {
 	m.Address = val
 }
 


### PR DESCRIPTION
Changes:

1. If a property is not required and not explicitly nullable, set a pointer so that it can be omitted when the generated Go struct is marshaled.
2. Add a test to validate the behaviour.
3. Fix the test numbering.
4. Verify and update tests that are impacted by this change.

## Ticket
#90 

## How Has This Been Verified?
Added a test case to ensure the change works as expected.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [x] New code can be debugged via logs.
- [x] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
