### PR TITLE
chore: bump go module to v2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,8 +20,8 @@ builds:
     main: ./main.go
     ldflags:
       - -s -w
-      - -X github.com/contiamo/openapi-generator-go/cmd/openapi-generator-go/cmd.GitCommit={{.Commit}}
-      - -X github.com/contiamo/openapi-generator-go/cmd/openapi-generator-go/cmd.Version={{.Version}}
+      - -X github.com/contiamo/openapi-generator-go/v2/cmd/openapi-generator-go/cmd.GitCommit={{.Commit}}
+      - -X github.com/contiamo/openapi-generator-go/v2/cmd/openapi-generator-go/cmd.Version={{.Version}}
 archives:
   - format: binary
 checksum:

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ test:
 ${GOBINS}/${.NAME}:  $(shell find . -name '*.go') go.*
 	@echo "+ $@"
 	go install -tags 'osusergo netgo' -v -ldflags "\
-		-X github.com/contiamo/openapi-generator-go/cmd/openapi-generator-go/cmd.GitCommit=$(GIT_COMMIT) \
-		-X github.com/contiamo/openapi-generator-go/cmd/openapi-generator-go/cmd.Version=$(GIT_VERSION)" \
+		-X github.com/contiamo/openapi-generator-go/v2/cmd/openapi-generator-go/cmd.GitCommit=$(GIT_COMMIT) \
+		-X github.com/contiamo/openapi-generator-go/v2/cmd/openapi-generator-go/cmd.Version=$(GIT_VERSION)" \
 		.
 
 install: ${GOBINS}/${.NAME}

--- a/cmd/openapi-generator-go/cmd/filter.go
+++ b/cmd/openapi-generator-go/cmd/filter.go
@@ -30,7 +30,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
-	"github.com/contiamo/openapi-generator-go/pkg/filters"
+	"github.com/contiamo/openapi-generator-go/v2/pkg/filters"
 )
 
 // filterCmd reads a list of allowed paths and filters the spec so that it

--- a/cmd/openapi-generator-go/cmd/merge.go
+++ b/cmd/openapi-generator-go/cmd/merge.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
-	"github.com/contiamo/openapi-generator-go/pkg/merge"
+	"github.com/contiamo/openapi-generator-go/v2/pkg/merge"
 )
 
 // mergeCmd merges a directory of openapi specs into a base spec.

--- a/cmd/openapi-generator-go/cmd/models.go
+++ b/cmd/openapi-generator-go/cmd/models.go
@@ -27,8 +27,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/contiamo/openapi-generator-go/pkg/filters"
-	"github.com/contiamo/openapi-generator-go/pkg/generators/models"
+	"github.com/contiamo/openapi-generator-go/v2/pkg/filters"
+	"github.com/contiamo/openapi-generator-go/v2/pkg/generators/models"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"

--- a/cmd/openapi-generator-go/cmd/router.go
+++ b/cmd/openapi-generator-go/cmd/router.go
@@ -26,8 +26,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/contiamo/openapi-generator-go/pkg/filters"
-	"github.com/contiamo/openapi-generator-go/pkg/generators/router"
+	"github.com/contiamo/openapi-generator-go/v2/pkg/filters"
+	"github.com/contiamo/openapi-generator-go/v2/pkg/generators/router"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/contiamo/openapi-generator-go
+module github.com/contiamo/openapi-generator-go/v2
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ THE SOFTWARE.
 */
 package main
 
-import "github.com/contiamo/openapi-generator-go/cmd/openapi-generator-go/cmd"
+import "github.com/contiamo/openapi-generator-go/v2/cmd/openapi-generator-go/cmd"
 
 func main() {
 	cmd.Execute()

--- a/pkg/generators/models/generate.go
+++ b/pkg/generators/models/generate.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	tpl "github.com/contiamo/openapi-generator-go/pkg/generators/templates"
+	tpl "github.com/contiamo/openapi-generator-go/v2/pkg/generators/templates"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"

--- a/pkg/generators/models/go_type_from_ref.go
+++ b/pkg/generators/models/go_type_from_ref.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 
-	tpl "github.com/contiamo/openapi-generator-go/pkg/generators/templates"
+	tpl "github.com/contiamo/openapi-generator-go/v2/pkg/generators/templates"
 )
 
 // goTypeFromSpec gets a Go type that can represent the schema

--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"text/template"
 
-	tpl "github.com/contiamo/openapi-generator-go/pkg/generators/templates"
+	tpl "github.com/contiamo/openapi-generator-go/v2/pkg/generators/templates"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/pkg/errors"
 )

--- a/pkg/generators/models/templates.go
+++ b/pkg/generators/models/templates.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 	"text/template"
 
-	tpl "github.com/contiamo/openapi-generator-go/pkg/generators/templates"
+	tpl "github.com/contiamo/openapi-generator-go/v2/pkg/generators/templates"
 )
 
 var (

--- a/pkg/generators/router/router.go
+++ b/pkg/generators/router/router.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"text/template"
 
-	tpl "github.com/contiamo/openapi-generator-go/pkg/generators/templates"
+	tpl "github.com/contiamo/openapi-generator-go/v2/pkg/generators/templates"
 	"github.com/rs/zerolog/log"
 	yaml "gopkg.in/yaml.v2"
 )


### PR DESCRIPTION
Add v2 to all of the module imports and the go.mod to prepare a v2 release.

Release-As: 2.0.0