### PR TITLE
fix: ensure nestd allOfs are correctly resolved

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/contiamo/openapi-generator-go/v2
 
-go 1.16
+go 1.19
 
 require (
 	github.com/getkin/kin-openapi v0.89.0
@@ -12,8 +12,28 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.9.0
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/sys v0.0.0-20211013075003-97ac67df715c // indirect
-	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e // indirect
+	github.com/mitchellh/mapstructure v1.4.2 // indirect
+	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/cast v1.4.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	golang.org/x/sys v0.0.0-20211013075003-97ac67df715c // indirect
+	golang.org/x/text v0.3.7 // indirect
+	gopkg.in/ini.v1 v1.63.2 // indirect
 )

--- a/pkg/generators/models/models_test.go
+++ b/pkg/generators/models/models_test.go
@@ -163,6 +163,10 @@ var cases = []struct {
 		name:      "example of object referencing other object that is not required and not nullable",
 		directory: "testdata/cases/not_required_not_nullable_object",
 	},
+	{
+		name:      "example resolving nested allOfs",
+		directory: "testdata/cases/allof_nesting",
+	},
 }
 
 func TestModels(t *testing.T) {
@@ -214,9 +218,9 @@ func TestModels(t *testing.T) {
 }
 
 func TestModelsSingleCase(t *testing.T) {
-	t.Skip("only used during local development")
+	// t.Skip("only used during local development")
 
-	tc := cases[33]
+	tc := cases[25]
 	count := 1
 	for i := 0; i < count; i++ {
 		t.Run(fmt.Sprintf("trial_%d_%s", i, tc.name), func(t *testing.T) {

--- a/pkg/generators/models/models_test.go
+++ b/pkg/generators/models/models_test.go
@@ -218,7 +218,7 @@ func TestModels(t *testing.T) {
 }
 
 func TestModelsSingleCase(t *testing.T) {
-	// t.Skip("only used during local development")
+	t.Skip("only used during local development")
 
 	tc := cases[25]
 	count := 1

--- a/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/api.yaml
+++ b/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/api.yaml
@@ -47,13 +47,13 @@ components:
     DataSourceTechnology:
       type: string
       description: |
-          Technology of a data source. For external data sources this also specifies the type of connection (driver) being used to connect to the data source. Generic data sources may use any technology value (but no connection will be established). Generic data sources may also use the value "other" for technology in case no technology should be shown in the catalog or the technology is not known to the catalog.
+        Technology of a data source. For external data sources this also specifies the type of connection (driver) being used to connect to the data source. Generic data sources may use any technology value (but no connection will be established). Generic data sources may also use the value "other" for technology in case no technology should be shown in the catalog or the technology is not known to the catalog.
       enum:
-          - mssql
-          - mysql
-          - oracle
-          - postgresql
-          - other
+        - mssql
+        - mysql
+        - oracle
+        - postgresql
+        - other
 
     IntegrationType:
       type: string

--- a/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/expected/model_connection.go
+++ b/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/expected/model_connection.go
@@ -47,7 +47,7 @@ func (m Connection) Validate() error {
 			m.Properties, validation.NotNil,
 		),
 		"technology": validation.Validate(
-			m.Technology, validation.NotNil,
+			m.Technology, validation.Required,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/generated/model_connection.go
+++ b/pkg/generators/models/testdata/cases/allOf_enum_merging_and_validation/generated/model_connection.go
@@ -47,7 +47,7 @@ func (m Connection) Validate() error {
 			m.Properties, validation.NotNil,
 		),
 		"technology": validation.Validate(
-			m.Technology, validation.NotNil,
+			m.Technology, validation.Required,
 		),
 	}.Filter()
 }

--- a/pkg/generators/models/testdata/cases/allof_nesting/api.yaml
+++ b/pkg/generators/models/testdata/cases/allof_nesting/api.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.0
+info:
+  version: 0.1.0
+  title: Test
+
+components:
+  schemas:
+    BaseEntity:
+      description: Contains shared properties for all the entities
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+
+    UpdatableEntity:
+      description: An entity that can be updated.
+      allOf:
+        - $ref: "#/components/schemas/BaseEntity"
+        - type: object
+          required:
+            - update_ts
+          properties:
+            update_ts:
+              type: integer
+
+    OrgEntity:
+      description: An organization
+      allOf:
+        - $ref: "#/components/schemas/UpdatableEntity"
+        - type: object
+          required:
+            - email
+          properties:
+            email:
+              type: string
+              format: email

--- a/pkg/generators/models/testdata/cases/allof_nesting/expected/model_base_entity.go
+++ b/pkg/generators/models/testdata/cases/allof_nesting/expected/model_base_entity.go
@@ -1,0 +1,49 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/go-ozzo/ozzo-validation/v4/is"
+)
+
+// BaseEntity is an object. Contains shared properties for all the entities
+type BaseEntity struct {
+	// Id:
+	Id string `json:"id" mapstructure:"id"`
+	// Name:
+	Name string `json:"name" mapstructure:"name"`
+}
+
+// Validate implements basic validation for this model
+func (m BaseEntity) Validate() error {
+	return validation.Errors{
+		"id": validation.Validate(
+			m.Id, validation.Required, is.UUID,
+		),
+	}.Filter()
+}
+
+// GetId returns the Id property
+func (m BaseEntity) GetId() string {
+	return m.Id
+}
+
+// SetId sets the Id property
+func (m *BaseEntity) SetId(val string) {
+	m.Id = val
+}
+
+// GetName returns the Name property
+func (m BaseEntity) GetName() string {
+	return m.Name
+}
+
+// SetName sets the Name property
+func (m *BaseEntity) SetName(val string) {
+	m.Name = val
+}

--- a/pkg/generators/models/testdata/cases/allof_nesting/expected/model_org_entity.go
+++ b/pkg/generators/models/testdata/cases/allof_nesting/expected/model_org_entity.go
@@ -1,0 +1,76 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/go-ozzo/ozzo-validation/v4/is"
+)
+
+// OrgEntity is an object. An organization
+type OrgEntity struct {
+	// Email:
+	Email string `json:"email" mapstructure:"email"`
+	// Id:
+	Id string `json:"id" mapstructure:"id"`
+	// Name:
+	Name string `json:"name" mapstructure:"name"`
+	// UpdateTs:
+	UpdateTs int32 `json:"update_ts" mapstructure:"update_ts"`
+}
+
+// Validate implements basic validation for this model
+func (m OrgEntity) Validate() error {
+	return validation.Errors{
+		"email": validation.Validate(
+			m.Email, validation.Required, is.EmailFormat,
+		),
+		"id": validation.Validate(
+			m.Id, validation.Required, is.UUID,
+		),
+	}.Filter()
+}
+
+// GetEmail returns the Email property
+func (m OrgEntity) GetEmail() string {
+	return m.Email
+}
+
+// SetEmail sets the Email property
+func (m *OrgEntity) SetEmail(val string) {
+	m.Email = val
+}
+
+// GetId returns the Id property
+func (m OrgEntity) GetId() string {
+	return m.Id
+}
+
+// SetId sets the Id property
+func (m *OrgEntity) SetId(val string) {
+	m.Id = val
+}
+
+// GetName returns the Name property
+func (m OrgEntity) GetName() string {
+	return m.Name
+}
+
+// SetName sets the Name property
+func (m *OrgEntity) SetName(val string) {
+	m.Name = val
+}
+
+// GetUpdateTs returns the UpdateTs property
+func (m OrgEntity) GetUpdateTs() int32 {
+	return m.UpdateTs
+}
+
+// SetUpdateTs sets the UpdateTs property
+func (m *OrgEntity) SetUpdateTs(val int32) {
+	m.UpdateTs = val
+}

--- a/pkg/generators/models/testdata/cases/allof_nesting/expected/model_updatable_entity.go
+++ b/pkg/generators/models/testdata/cases/allof_nesting/expected/model_updatable_entity.go
@@ -1,0 +1,61 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/go-ozzo/ozzo-validation/v4/is"
+)
+
+// UpdatableEntity is an object. An entity that can be updated.
+type UpdatableEntity struct {
+	// Id:
+	Id string `json:"id" mapstructure:"id"`
+	// Name:
+	Name string `json:"name" mapstructure:"name"`
+	// UpdateTs:
+	UpdateTs int32 `json:"update_ts" mapstructure:"update_ts"`
+}
+
+// Validate implements basic validation for this model
+func (m UpdatableEntity) Validate() error {
+	return validation.Errors{
+		"id": validation.Validate(
+			m.Id, validation.Required, is.UUID,
+		),
+	}.Filter()
+}
+
+// GetId returns the Id property
+func (m UpdatableEntity) GetId() string {
+	return m.Id
+}
+
+// SetId sets the Id property
+func (m *UpdatableEntity) SetId(val string) {
+	m.Id = val
+}
+
+// GetName returns the Name property
+func (m UpdatableEntity) GetName() string {
+	return m.Name
+}
+
+// SetName sets the Name property
+func (m *UpdatableEntity) SetName(val string) {
+	m.Name = val
+}
+
+// GetUpdateTs returns the UpdateTs property
+func (m UpdatableEntity) GetUpdateTs() int32 {
+	return m.UpdateTs
+}
+
+// SetUpdateTs sets the UpdateTs property
+func (m *UpdatableEntity) SetUpdateTs(val int32) {
+	m.UpdateTs = val
+}

--- a/pkg/generators/models/testdata/cases/allof_nesting/generated/model_base_entity.go
+++ b/pkg/generators/models/testdata/cases/allof_nesting/generated/model_base_entity.go
@@ -1,0 +1,49 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/go-ozzo/ozzo-validation/v4/is"
+)
+
+// BaseEntity is an object. Contains shared properties for all the entities
+type BaseEntity struct {
+	// Id:
+	Id string `json:"id" mapstructure:"id"`
+	// Name:
+	Name string `json:"name" mapstructure:"name"`
+}
+
+// Validate implements basic validation for this model
+func (m BaseEntity) Validate() error {
+	return validation.Errors{
+		"id": validation.Validate(
+			m.Id, validation.Required, is.UUID,
+		),
+	}.Filter()
+}
+
+// GetId returns the Id property
+func (m BaseEntity) GetId() string {
+	return m.Id
+}
+
+// SetId sets the Id property
+func (m *BaseEntity) SetId(val string) {
+	m.Id = val
+}
+
+// GetName returns the Name property
+func (m BaseEntity) GetName() string {
+	return m.Name
+}
+
+// SetName sets the Name property
+func (m *BaseEntity) SetName(val string) {
+	m.Name = val
+}

--- a/pkg/generators/models/testdata/cases/allof_nesting/generated/model_org_entity.go
+++ b/pkg/generators/models/testdata/cases/allof_nesting/generated/model_org_entity.go
@@ -1,0 +1,76 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/go-ozzo/ozzo-validation/v4/is"
+)
+
+// OrgEntity is an object. An organization
+type OrgEntity struct {
+	// Email:
+	Email string `json:"email" mapstructure:"email"`
+	// Id:
+	Id string `json:"id" mapstructure:"id"`
+	// Name:
+	Name string `json:"name" mapstructure:"name"`
+	// UpdateTs:
+	UpdateTs int32 `json:"update_ts" mapstructure:"update_ts"`
+}
+
+// Validate implements basic validation for this model
+func (m OrgEntity) Validate() error {
+	return validation.Errors{
+		"email": validation.Validate(
+			m.Email, validation.Required, is.EmailFormat,
+		),
+		"id": validation.Validate(
+			m.Id, validation.Required, is.UUID,
+		),
+	}.Filter()
+}
+
+// GetEmail returns the Email property
+func (m OrgEntity) GetEmail() string {
+	return m.Email
+}
+
+// SetEmail sets the Email property
+func (m *OrgEntity) SetEmail(val string) {
+	m.Email = val
+}
+
+// GetId returns the Id property
+func (m OrgEntity) GetId() string {
+	return m.Id
+}
+
+// SetId sets the Id property
+func (m *OrgEntity) SetId(val string) {
+	m.Id = val
+}
+
+// GetName returns the Name property
+func (m OrgEntity) GetName() string {
+	return m.Name
+}
+
+// SetName sets the Name property
+func (m *OrgEntity) SetName(val string) {
+	m.Name = val
+}
+
+// GetUpdateTs returns the UpdateTs property
+func (m OrgEntity) GetUpdateTs() int32 {
+	return m.UpdateTs
+}
+
+// SetUpdateTs sets the UpdateTs property
+func (m *OrgEntity) SetUpdateTs(val int32) {
+	m.UpdateTs = val
+}

--- a/pkg/generators/models/testdata/cases/allof_nesting/generated/model_updatable_entity.go
+++ b/pkg/generators/models/testdata/cases/allof_nesting/generated/model_updatable_entity.go
@@ -1,0 +1,61 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/go-ozzo/ozzo-validation/v4/is"
+)
+
+// UpdatableEntity is an object. An entity that can be updated.
+type UpdatableEntity struct {
+	// Id:
+	Id string `json:"id" mapstructure:"id"`
+	// Name:
+	Name string `json:"name" mapstructure:"name"`
+	// UpdateTs:
+	UpdateTs int32 `json:"update_ts" mapstructure:"update_ts"`
+}
+
+// Validate implements basic validation for this model
+func (m UpdatableEntity) Validate() error {
+	return validation.Errors{
+		"id": validation.Validate(
+			m.Id, validation.Required, is.UUID,
+		),
+	}.Filter()
+}
+
+// GetId returns the Id property
+func (m UpdatableEntity) GetId() string {
+	return m.Id
+}
+
+// SetId sets the Id property
+func (m *UpdatableEntity) SetId(val string) {
+	m.Id = val
+}
+
+// GetName returns the Name property
+func (m UpdatableEntity) GetName() string {
+	return m.Name
+}
+
+// SetName sets the Name property
+func (m *UpdatableEntity) SetName(val string) {
+	m.Name = val
+}
+
+// GetUpdateTs returns the UpdateTs property
+func (m UpdatableEntity) GetUpdateTs() int32 {
+	return m.UpdateTs
+}
+
+// SetUpdateTs sets the UpdateTs property
+func (m *UpdatableEntity) SetUpdateTs(val int32) {
+	m.UpdateTs = val
+}


### PR DESCRIPTION
Adjust the schema merge logic to include allOf resolution. This ensures that nested allOf's are correctly merged together.

Adjust some of the model properties generation to handle some edge cases that were discovered for singleton allOfs.

Resolves #94

