### PR TITLE
fix: support numberic enum types

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Our generator differs from the official OpenAPI generator tools by also providin
 
 We also provide better support for :
 * [enums](./pkg/generators/models/testdata/cases/enums/expected/model_filter_type.go), enum support also includes some utility methods that make validating the enums much easier,
+  * Now including support for string, integer, and number (i.e. decimal) enums.
 * [arrays](./pkg/generators/models/testdata/cases/typed_arrays/expected/model_foo.go),
 * [allOf](./pkg/generators/models/testdata/cases/allof1/expected/model_foo.go),
 * and [oneOf](./pkg/generators/models/testdata/cases/oneof/expected/model_foo.go)

--- a/pkg/generators/models/models.go
+++ b/pkg/generators/models/models.go
@@ -150,8 +150,8 @@ func NewModelFromRef(ref *openapi3.SchemaRef) (model *Model, err error) {
 	switch {
 	case len(ref.Value.Enum) > 0:
 		model.Kind = Enum
-		model.Properties = enumPropsFromRef(ref, model)
 		model.GoType = goTypeFromSpec(ref)
+		model.Properties = enumPropsFromRef(ref, model)
 
 	case ref.Value.Type == "object" || len(ref.Value.Properties) > 0:
 		model.Kind = Struct
@@ -769,9 +769,16 @@ func enumPropsFromRef(ref *openapi3.SchemaRef, model *Model) (specs []PropSpec) 
 			valueVarName = fmt.Sprintf("Item%d", idx)
 		}
 
+		var enumValue string
+		switch ref.Value.Type {
+		case "integer", "number":
+			enumValue = fmt.Sprintf("%v", val)
+		default:
+			enumValue = fmt.Sprintf(`"%v"`, val)
+		}
 		specs = append(specs, PropSpec{
 			Name:   valueVarName,
-			Value:  fmt.Sprintf(`"%v"`, val),
+			Value:  enumValue,
 			GoType: model.Name,
 		})
 	}

--- a/pkg/generators/models/models_test.go
+++ b/pkg/generators/models/models_test.go
@@ -167,6 +167,15 @@ var cases = []struct {
 		name:      "example resolving nested allOfs",
 		directory: "testdata/cases/allof_nesting",
 	},
+	// 35
+	{
+		name:      "example of an enum with integer values",
+		directory: "testdata/cases/enum_with_integer_values",
+	},
+	{
+		name:      "example of an enum with number values",
+		directory: "testdata/cases/enum_with_number_values",
+	},
 }
 
 func TestModels(t *testing.T) {

--- a/pkg/generators/models/testdata/cases/enum_with_integer_values/api.yaml
+++ b/pkg/generators/models/testdata/cases/enum_with_integer_values/api.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.0
+info:
+  version: 0.1.0
+  title: Test
+
+components:
+  schemas:
+    FavoriteNumber:
+      type: integer
+      enum:
+        - 1
+        - 3
+        - 5
+        - 8

--- a/pkg/generators/models/testdata/cases/enum_with_integer_values/expected/model_favorite_number.go
+++ b/pkg/generators/models/testdata/cases/enum_with_integer_values/expected/model_favorite_number.go
@@ -1,0 +1,49 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// FavoriteNumber is an enum.
+type FavoriteNumber int32
+
+// Validate implements basic validation for this model
+func (m FavoriteNumber) Validate() error {
+	return InKnownFavoriteNumber.Validate(m)
+}
+
+var (
+	FavoriteNumber1 FavoriteNumber = 1
+	FavoriteNumber3 FavoriteNumber = 3
+	FavoriteNumber5 FavoriteNumber = 5
+	FavoriteNumber8 FavoriteNumber = 8
+
+	// KnownFavoriteNumber is the list of valid FavoriteNumber
+	KnownFavoriteNumber = []FavoriteNumber{
+		FavoriteNumber1,
+		FavoriteNumber3,
+		FavoriteNumber5,
+		FavoriteNumber8,
+	}
+	// KnownFavoriteNumberInt32 is the list of valid FavoriteNumber as int32
+	KnownFavoriteNumberInt32 = []int32{
+		int32(FavoriteNumber1),
+		int32(FavoriteNumber3),
+		int32(FavoriteNumber5),
+		int32(FavoriteNumber8),
+	}
+
+	// InKnownFavoriteNumber is an ozzo-validator for FavoriteNumber
+	InKnownFavoriteNumber = validation.In(
+		FavoriteNumber1,
+		FavoriteNumber3,
+		FavoriteNumber5,
+		FavoriteNumber8,
+	)
+)

--- a/pkg/generators/models/testdata/cases/enum_with_integer_values/generated/model_favorite_number.go
+++ b/pkg/generators/models/testdata/cases/enum_with_integer_values/generated/model_favorite_number.go
@@ -1,0 +1,49 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// FavoriteNumber is an enum.
+type FavoriteNumber int32
+
+// Validate implements basic validation for this model
+func (m FavoriteNumber) Validate() error {
+	return InKnownFavoriteNumber.Validate(m)
+}
+
+var (
+	FavoriteNumber1 FavoriteNumber = 1
+	FavoriteNumber3 FavoriteNumber = 3
+	FavoriteNumber5 FavoriteNumber = 5
+	FavoriteNumber8 FavoriteNumber = 8
+
+	// KnownFavoriteNumber is the list of valid FavoriteNumber
+	KnownFavoriteNumber = []FavoriteNumber{
+		FavoriteNumber1,
+		FavoriteNumber3,
+		FavoriteNumber5,
+		FavoriteNumber8,
+	}
+	// KnownFavoriteNumberInt32 is the list of valid FavoriteNumber as int32
+	KnownFavoriteNumberInt32 = []int32{
+		int32(FavoriteNumber1),
+		int32(FavoriteNumber3),
+		int32(FavoriteNumber5),
+		int32(FavoriteNumber8),
+	}
+
+	// InKnownFavoriteNumber is an ozzo-validator for FavoriteNumber
+	InKnownFavoriteNumber = validation.In(
+		FavoriteNumber1,
+		FavoriteNumber3,
+		FavoriteNumber5,
+		FavoriteNumber8,
+	)
+)

--- a/pkg/generators/models/testdata/cases/enum_with_number_values/api.yaml
+++ b/pkg/generators/models/testdata/cases/enum_with_number_values/api.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.0
+info:
+  version: 0.1.0
+  title: Test
+
+components:
+  schemas:
+    FavoriteNumber:
+      type: number
+      enum:
+        - 3.141
+        - 2.718
+        - 6.0228
+        - 1.381

--- a/pkg/generators/models/testdata/cases/enum_with_number_values/expected/model_favorite_number.go
+++ b/pkg/generators/models/testdata/cases/enum_with_number_values/expected/model_favorite_number.go
@@ -1,0 +1,49 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// FavoriteNumber is an enum.
+type FavoriteNumber float32
+
+// Validate implements basic validation for this model
+func (m FavoriteNumber) Validate() error {
+	return InKnownFavoriteNumber.Validate(m)
+}
+
+var (
+	FavoriteNumber1381  FavoriteNumber = 1.381
+	FavoriteNumber2718  FavoriteNumber = 2.718
+	FavoriteNumber3141  FavoriteNumber = 3.141
+	FavoriteNumber60228 FavoriteNumber = 6.0228
+
+	// KnownFavoriteNumber is the list of valid FavoriteNumber
+	KnownFavoriteNumber = []FavoriteNumber{
+		FavoriteNumber1381,
+		FavoriteNumber2718,
+		FavoriteNumber3141,
+		FavoriteNumber60228,
+	}
+	// KnownFavoriteNumberFloat32 is the list of valid FavoriteNumber as float32
+	KnownFavoriteNumberFloat32 = []float32{
+		float32(FavoriteNumber1381),
+		float32(FavoriteNumber2718),
+		float32(FavoriteNumber3141),
+		float32(FavoriteNumber60228),
+	}
+
+	// InKnownFavoriteNumber is an ozzo-validator for FavoriteNumber
+	InKnownFavoriteNumber = validation.In(
+		FavoriteNumber1381,
+		FavoriteNumber2718,
+		FavoriteNumber3141,
+		FavoriteNumber60228,
+	)
+)

--- a/pkg/generators/models/testdata/cases/enum_with_number_values/generated/model_favorite_number.go
+++ b/pkg/generators/models/testdata/cases/enum_with_number_values/generated/model_favorite_number.go
@@ -1,0 +1,49 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// FavoriteNumber is an enum.
+type FavoriteNumber float32
+
+// Validate implements basic validation for this model
+func (m FavoriteNumber) Validate() error {
+	return InKnownFavoriteNumber.Validate(m)
+}
+
+var (
+	FavoriteNumber1381  FavoriteNumber = 1.381
+	FavoriteNumber2718  FavoriteNumber = 2.718
+	FavoriteNumber3141  FavoriteNumber = 3.141
+	FavoriteNumber60228 FavoriteNumber = 6.0228
+
+	// KnownFavoriteNumber is the list of valid FavoriteNumber
+	KnownFavoriteNumber = []FavoriteNumber{
+		FavoriteNumber1381,
+		FavoriteNumber2718,
+		FavoriteNumber3141,
+		FavoriteNumber60228,
+	}
+	// KnownFavoriteNumberFloat32 is the list of valid FavoriteNumber as float32
+	KnownFavoriteNumberFloat32 = []float32{
+		float32(FavoriteNumber1381),
+		float32(FavoriteNumber2718),
+		float32(FavoriteNumber3141),
+		float32(FavoriteNumber60228),
+	}
+
+	// InKnownFavoriteNumber is an ozzo-validator for FavoriteNumber
+	InKnownFavoriteNumber = validation.In(
+		FavoriteNumber1381,
+		FavoriteNumber2718,
+		FavoriteNumber3141,
+		FavoriteNumber60228,
+	)
+)


### PR DESCRIPTION
Adjust the enum model generator so that we do not automatically quote all enum values. For integer and number types, the raw un-quoted value is used instead.

Resolves #97 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [x] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
