### PR TITLE
fix: Not all schema references are properly formatted GoTypes

### DIFF
--- a/pkg/generators/models/go_type_from_ref.go
+++ b/pkg/generators/models/go_type_from_ref.go
@@ -81,7 +81,7 @@ func goTypeFromSpec(schemaRef *openapi3.SchemaRef) string {
 		}
 
 	case "ref":
-		propertyType = filepath.Base(schemaRef.Ref)
+		propertyType = typeNameFromRef(schemaRef.Ref)
 	case "":
 		propertyType = "interface{}"
 	}
@@ -151,7 +151,9 @@ func goTypeForObject(schemaRef *openapi3.SchemaRef) (propType string) {
 	return propType
 }
 
-var typeNameFromRef = filepath.Base
+var typeNameFromRef = func(ref string) string {
+	return tpl.ToPascalCase(filepath.Base(ref))
+}
 
 func sortedKeys(obj map[string]*openapi3.SchemaRef) (res []string) {
 	for k := range obj {

--- a/pkg/generators/models/testdata/cases/parameter_model/api.yaml
+++ b/pkg/generators/models/testdata/cases/parameter_model/api.yaml
@@ -32,6 +32,10 @@ paths:
             type: array
             items:
               type: string
+        - name: param4
+          in: query
+          schema:
+            "$ref": "#/components/schemas/referenced-status"
         - $ref: "#/components/parameters/PageNumber"
       responses:
         "200":
@@ -48,4 +52,13 @@ components:
         type: integer
         minimum: 1
         default: 1
-  schemas: {}
+
+  schemas:
+    referenced-status:
+      type: string
+      description: A referenced status
+      enum:
+      - open
+      - closed
+      - dismissed
+      - fixed

--- a/pkg/generators/models/testdata/cases/parameter_model/expected/model_get_foo_query_parameters.go
+++ b/pkg/generators/models/testdata/cases/parameter_model/expected/model_get_foo_query_parameters.go
@@ -21,6 +21,8 @@ type GetFooQueryParameters struct {
 	Param2 int32 `json:"param2,omitempty" mapstructure:"param2,omitempty"`
 	// Param3:
 	Param3 []string `json:"param3,omitempty" mapstructure:"param3,omitempty"`
+	// Param4:
+	Param4 ReferencedStatus `json:"param4,omitempty" mapstructure:"param4,omitempty"`
 	// Page: The current set of paged results to display, based on a 1-based array index
 	Page int32 `json:"page,omitempty" mapstructure:"page,omitempty"`
 }
@@ -39,6 +41,9 @@ func (m GetFooQueryParameters) Validate() error {
 		),
 		"param3": validation.Validate(
 			m.Param3,
+		),
+		"param4": validation.Validate(
+			m.Param4,
 		),
 		"page": validation.Validate(
 			m.Page, validation.Min(int32(1)),
@@ -84,6 +89,16 @@ func (m GetFooQueryParameters) GetParam3() []string {
 // SetParam3 sets the Param3 property
 func (m *GetFooQueryParameters) SetParam3(val []string) {
 	m.Param3 = val
+}
+
+// GetParam4 returns the Param4 property
+func (m GetFooQueryParameters) GetParam4() ReferencedStatus {
+	return m.Param4
+}
+
+// SetParam4 sets the Param4 property
+func (m *GetFooQueryParameters) SetParam4(val ReferencedStatus) {
+	m.Param4 = val
 }
 
 // GetPage returns the Page property

--- a/pkg/generators/models/testdata/cases/parameter_model/expected/model_referenced_status.go
+++ b/pkg/generators/models/testdata/cases/parameter_model/expected/model_referenced_status.go
@@ -1,0 +1,49 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// ReferencedStatus is an enum. A referenced status
+type ReferencedStatus string
+
+// Validate implements basic validation for this model
+func (m ReferencedStatus) Validate() error {
+	return InKnownReferencedStatus.Validate(m)
+}
+
+var (
+	ReferencedStatusClosed    ReferencedStatus = "closed"
+	ReferencedStatusDismissed ReferencedStatus = "dismissed"
+	ReferencedStatusFixed     ReferencedStatus = "fixed"
+	ReferencedStatusOpen      ReferencedStatus = "open"
+
+	// KnownReferencedStatus is the list of valid ReferencedStatus
+	KnownReferencedStatus = []ReferencedStatus{
+		ReferencedStatusClosed,
+		ReferencedStatusDismissed,
+		ReferencedStatusFixed,
+		ReferencedStatusOpen,
+	}
+	// KnownReferencedStatusString is the list of valid ReferencedStatus as string
+	KnownReferencedStatusString = []string{
+		string(ReferencedStatusClosed),
+		string(ReferencedStatusDismissed),
+		string(ReferencedStatusFixed),
+		string(ReferencedStatusOpen),
+	}
+
+	// InKnownReferencedStatus is an ozzo-validator for ReferencedStatus
+	InKnownReferencedStatus = validation.In(
+		ReferencedStatusClosed,
+		ReferencedStatusDismissed,
+		ReferencedStatusFixed,
+		ReferencedStatusOpen,
+	)
+)

--- a/pkg/generators/models/testdata/cases/parameter_model/generated/model_get_foo_query_parameters.go
+++ b/pkg/generators/models/testdata/cases/parameter_model/generated/model_get_foo_query_parameters.go
@@ -21,6 +21,8 @@ type GetFooQueryParameters struct {
 	Param2 int32 `json:"param2,omitempty" mapstructure:"param2,omitempty"`
 	// Param3:
 	Param3 []string `json:"param3,omitempty" mapstructure:"param3,omitempty"`
+	// Param4:
+	Param4 ReferencedStatus `json:"param4,omitempty" mapstructure:"param4,omitempty"`
 	// Page: The current set of paged results to display, based on a 1-based array index
 	Page int32 `json:"page,omitempty" mapstructure:"page,omitempty"`
 }
@@ -39,6 +41,9 @@ func (m GetFooQueryParameters) Validate() error {
 		),
 		"param3": validation.Validate(
 			m.Param3,
+		),
+		"param4": validation.Validate(
+			m.Param4,
 		),
 		"page": validation.Validate(
 			m.Page, validation.Min(int32(1)),
@@ -84,6 +89,16 @@ func (m GetFooQueryParameters) GetParam3() []string {
 // SetParam3 sets the Param3 property
 func (m *GetFooQueryParameters) SetParam3(val []string) {
 	m.Param3 = val
+}
+
+// GetParam4 returns the Param4 property
+func (m GetFooQueryParameters) GetParam4() ReferencedStatus {
+	return m.Param4
+}
+
+// SetParam4 sets the Param4 property
+func (m *GetFooQueryParameters) SetParam4(val ReferencedStatus) {
+	m.Param4 = val
 }
 
 // GetPage returns the Page property

--- a/pkg/generators/models/testdata/cases/parameter_model/generated/model_referenced_status.go
+++ b/pkg/generators/models/testdata/cases/parameter_model/generated/model_referenced_status.go
@@ -1,0 +1,49 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+// ReferencedStatus is an enum. A referenced status
+type ReferencedStatus string
+
+// Validate implements basic validation for this model
+func (m ReferencedStatus) Validate() error {
+	return InKnownReferencedStatus.Validate(m)
+}
+
+var (
+	ReferencedStatusClosed    ReferencedStatus = "closed"
+	ReferencedStatusDismissed ReferencedStatus = "dismissed"
+	ReferencedStatusFixed     ReferencedStatus = "fixed"
+	ReferencedStatusOpen      ReferencedStatus = "open"
+
+	// KnownReferencedStatus is the list of valid ReferencedStatus
+	KnownReferencedStatus = []ReferencedStatus{
+		ReferencedStatusClosed,
+		ReferencedStatusDismissed,
+		ReferencedStatusFixed,
+		ReferencedStatusOpen,
+	}
+	// KnownReferencedStatusString is the list of valid ReferencedStatus as string
+	KnownReferencedStatusString = []string{
+		string(ReferencedStatusClosed),
+		string(ReferencedStatusDismissed),
+		string(ReferencedStatusFixed),
+		string(ReferencedStatusOpen),
+	}
+
+	// InKnownReferencedStatus is an ozzo-validator for ReferencedStatus
+	InKnownReferencedStatus = validation.In(
+		ReferencedStatusClosed,
+		ReferencedStatusDismissed,
+		ReferencedStatusFixed,
+		ReferencedStatusOpen,
+	)
+)


### PR DESCRIPTION
PR 1 for #100 
Make sure that in case a $ref is used the TypeName is formatted (more) properly in PascalCase

## Ticket
[#100](https://github.com/contiamo/openapi-generator-go/issues/100)

## How Has This Been Verified?
Tests introduced in parameter-model api.yaml 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The change works as expected.
- [ ] New code can be debugged via logs.
- [x] I have added tests to cover my changes.
- [x] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
