### PR TITLE
fix: anonymous types need proper formatting

### DIFF
--- a/pkg/generators/models/templates/oneof.gotpl
+++ b/pkg/generators/models/templates/oneof.gotpl
@@ -109,7 +109,7 @@ func (m *{{$modelName}}) UnmarshalJSON(bs []byte) error {
 }
 
 {{- range $convert := .ConvertSpecs }}
-// From{{firstUpper $convert.TargetGoType}} sets the {{$modelName}} data.
+{{ (printf "From%s sets the %s from a %s"  ($convert.TargetGoType | typeDisplayName) $modelName $convert.TargetGoType) | commentBlock }}
 func (m *{{$modelName}}) From{{$convert.TargetGoType | typeDisplayName}}(data {{$convert.TargetGoType}}) {
 	m.data = data
 }
@@ -127,7 +127,7 @@ func (m {{$modelName}}) As(target interface{}) error {
 }
 
 {{- range $convert := .ConvertSpecs }}
-// As{{firstUpper $convert.TargetGoType}} converts {{$modelName}} to a {{$convert.TargetGoType}}
+{{ (printf "As%s converts %s to a %s"  ($convert.TargetGoType | typeDisplayName) $modelName $convert.TargetGoType) | commentBlock }}
 func (m {{$modelName}}) As{{$convert.TargetGoType | typeDisplayName }}() (result {{$convert.TargetGoType}}, err error) {
 	{{- if $.Discriminator.Field }}
 	if m.data == nil {

--- a/pkg/generators/models/testdata/cases/nested_inline_arrays/expected/model_geometry.go
+++ b/pkg/generators/models/testdata/cases/nested_inline_arrays/expected/model_geometry.go
@@ -94,12 +94,12 @@ func (m *Geometry) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-// FromLine sets the Geometry data.
+// FromLine sets the Geometry from a Line
 func (m *Geometry) FromLine(data Line) {
 	m.data = data
 }
 
-// FromShape sets the Geometry data.
+// FromShape sets the Geometry from a Shape
 func (m *Geometry) FromShape(data Shape) {
 	m.data = data
 }

--- a/pkg/generators/models/testdata/cases/nested_inline_arrays/generated/model_geometry.go
+++ b/pkg/generators/models/testdata/cases/nested_inline_arrays/generated/model_geometry.go
@@ -94,12 +94,12 @@ func (m *Geometry) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-// FromLine sets the Geometry data.
+// FromLine sets the Geometry from a Line
 func (m *Geometry) FromLine(data Line) {
 	m.data = data
 }
 
-// FromShape sets the Geometry data.
+// FromShape sets the Geometry from a Shape
 func (m *Geometry) FromShape(data Shape) {
 	m.data = data
 }

--- a/pkg/generators/models/testdata/cases/oneof/api.yaml
+++ b/pkg/generators/models/testdata/cases/oneof/api.yaml
@@ -35,7 +35,22 @@ components:
       description: One field from query results
       nullable: true
       oneOf:
-      - nullable: true
-        type: string
-      - type: boolean
-      - type: number
+        - nullable: true
+          type: string
+        - type: boolean
+        - type: number
+
+    EitherIdOrNamespaceName:
+      description: Either an object with id or a namespace with a name
+      nullable: true
+      oneOf:
+        - type: object
+          properties:
+            id:
+              type: string
+        - type: object
+          properties:
+            namespace:
+              type: string
+            name:
+              type: string

--- a/pkg/generators/models/testdata/cases/oneof/expected/model_bar.go
+++ b/pkg/generators/models/testdata/cases/oneof/expected/model_bar.go
@@ -26,12 +26,12 @@ func (m *Bar) UnmarshalJSON(bs []byte) error {
 	return json.Unmarshal(bs, &m.data)
 }
 
-// FromString sets the Bar data.
+// FromString sets the Bar from a string
 func (m *Bar) FromString(data string) {
 	m.data = data
 }
 
-// FromInt32 sets the Bar data.
+// FromInt32 sets the Bar from a int32
 func (m *Bar) FromInt32(data int32) {
 	m.data = data
 }

--- a/pkg/generators/models/testdata/cases/oneof/expected/model_baz.go
+++ b/pkg/generators/models/testdata/cases/oneof/expected/model_baz.go
@@ -26,17 +26,17 @@ func (m *Baz) UnmarshalJSON(bs []byte) error {
 	return json.Unmarshal(bs, &m.data)
 }
 
-// FromFoo sets the Baz data.
+// FromFoo sets the Baz from a Foo
 func (m *Baz) FromFoo(data Foo) {
 	m.data = data
 }
 
-// FromBar sets the Baz data.
+// FromBar sets the Baz from a Bar
 func (m *Baz) FromBar(data Bar) {
 	m.data = data
 }
 
-// FromPerson sets the Baz data.
+// FromPerson sets the Baz from a Person
 func (m *Baz) FromPerson(data Person) {
 	m.data = data
 }

--- a/pkg/generators/models/testdata/cases/oneof/expected/model_either_id_or_namespace_name.go
+++ b/pkg/generators/models/testdata/cases/oneof/expected/model_either_id_or_namespace_name.go
@@ -1,0 +1,72 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	"encoding/json"
+	"github.com/mitchellh/mapstructure"
+)
+
+// EitherIdOrNamespaceName is a oneOf type. Either an object with id or a namespace with a name
+type EitherIdOrNamespaceName struct {
+	data interface{}
+}
+
+// MarshalJSON implements the json.Marshaller interface
+func (m EitherIdOrNamespaceName) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.data)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface
+func (m *EitherIdOrNamespaceName) UnmarshalJSON(bs []byte) error {
+	return json.Unmarshal(bs, &m.data)
+}
+
+// FromStructId sets the EitherIdOrNamespaceName from a struct {
+// Id string `json:"id,omitempty" mapstructure:"id,omitempty"`
+// }
+func (m *EitherIdOrNamespaceName) FromStructId(data struct {
+	Id string `json:"id,omitempty" mapstructure:"id,omitempty"`
+}) {
+	m.data = data
+}
+
+// FromStructNameNamespace sets the EitherIdOrNamespaceName from a struct {
+// Name string `json:"name,omitempty" mapstructure:"name,omitempty"`
+// Namespace string `json:"namespace,omitempty" mapstructure:"namespace,omitempty"`
+// }
+func (m *EitherIdOrNamespaceName) FromStructNameNamespace(data struct {
+	Name      string `json:"name,omitempty" mapstructure:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty" mapstructure:"namespace,omitempty"`
+}) {
+	m.data = data
+}
+
+// As converts EitherIdOrNamespaceName to a user defined structure.
+func (m EitherIdOrNamespaceName) As(target interface{}) error {
+	return mapstructure.Decode(m.data, target)
+}
+
+// AsStructId converts EitherIdOrNamespaceName to a struct {
+// Id string `json:"id,omitempty" mapstructure:"id,omitempty"`
+// }
+func (m EitherIdOrNamespaceName) AsStructId() (result struct {
+	Id string `json:"id,omitempty" mapstructure:"id,omitempty"`
+}, err error) {
+	return result, mapstructure.Decode(m.data, &result)
+}
+
+// AsStructNameNamespace converts EitherIdOrNamespaceName to a struct {
+// Name string `json:"name,omitempty" mapstructure:"name,omitempty"`
+// Namespace string `json:"namespace,omitempty" mapstructure:"namespace,omitempty"`
+// }
+func (m EitherIdOrNamespaceName) AsStructNameNamespace() (result struct {
+	Name      string `json:"name,omitempty" mapstructure:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty" mapstructure:"namespace,omitempty"`
+}, err error) {
+	return result, mapstructure.Decode(m.data, &result)
+}

--- a/pkg/generators/models/testdata/cases/oneof/expected/model_query_response_row_entry.go
+++ b/pkg/generators/models/testdata/cases/oneof/expected/model_query_response_row_entry.go
@@ -26,17 +26,17 @@ func (m *QueryResponseRowEntry) UnmarshalJSON(bs []byte) error {
 	return json.Unmarshal(bs, &m.data)
 }
 
-// From*string sets the QueryResponseRowEntry data.
+// FromNullableString sets the QueryResponseRowEntry from a *string
 func (m *QueryResponseRowEntry) FromNullableString(data *string) {
 	m.data = data
 }
 
-// FromBool sets the QueryResponseRowEntry data.
+// FromBool sets the QueryResponseRowEntry from a bool
 func (m *QueryResponseRowEntry) FromBool(data bool) {
 	m.data = data
 }
 
-// FromFloat32 sets the QueryResponseRowEntry data.
+// FromFloat32 sets the QueryResponseRowEntry from a float32
 func (m *QueryResponseRowEntry) FromFloat32(data float32) {
 	m.data = data
 }
@@ -46,7 +46,7 @@ func (m QueryResponseRowEntry) As(target interface{}) error {
 	return mapstructure.Decode(m.data, target)
 }
 
-// As*string converts QueryResponseRowEntry to a *string
+// AsNullableString converts QueryResponseRowEntry to a *string
 func (m QueryResponseRowEntry) AsNullableString() (result *string, err error) {
 	return result, mapstructure.Decode(m.data, &result)
 }

--- a/pkg/generators/models/testdata/cases/oneof/generated/model_bar.go
+++ b/pkg/generators/models/testdata/cases/oneof/generated/model_bar.go
@@ -26,12 +26,12 @@ func (m *Bar) UnmarshalJSON(bs []byte) error {
 	return json.Unmarshal(bs, &m.data)
 }
 
-// FromString sets the Bar data.
+// FromString sets the Bar from a string
 func (m *Bar) FromString(data string) {
 	m.data = data
 }
 
-// FromInt32 sets the Bar data.
+// FromInt32 sets the Bar from a int32
 func (m *Bar) FromInt32(data int32) {
 	m.data = data
 }

--- a/pkg/generators/models/testdata/cases/oneof/generated/model_baz.go
+++ b/pkg/generators/models/testdata/cases/oneof/generated/model_baz.go
@@ -26,17 +26,17 @@ func (m *Baz) UnmarshalJSON(bs []byte) error {
 	return json.Unmarshal(bs, &m.data)
 }
 
-// FromFoo sets the Baz data.
+// FromFoo sets the Baz from a Foo
 func (m *Baz) FromFoo(data Foo) {
 	m.data = data
 }
 
-// FromBar sets the Baz data.
+// FromBar sets the Baz from a Bar
 func (m *Baz) FromBar(data Bar) {
 	m.data = data
 }
 
-// FromPerson sets the Baz data.
+// FromPerson sets the Baz from a Person
 func (m *Baz) FromPerson(data Person) {
 	m.data = data
 }

--- a/pkg/generators/models/testdata/cases/oneof/generated/model_either_id_or_namespace_name.go
+++ b/pkg/generators/models/testdata/cases/oneof/generated/model_either_id_or_namespace_name.go
@@ -1,0 +1,72 @@
+// This file is auto-generated, DO NOT EDIT.
+//
+// Source:
+//
+//	Title: Test
+//	Version: 0.1.0
+package generatortest
+
+import (
+	"encoding/json"
+	"github.com/mitchellh/mapstructure"
+)
+
+// EitherIdOrNamespaceName is a oneOf type. Either an object with id or a namespace with a name
+type EitherIdOrNamespaceName struct {
+	data interface{}
+}
+
+// MarshalJSON implements the json.Marshaller interface
+func (m EitherIdOrNamespaceName) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.data)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface
+func (m *EitherIdOrNamespaceName) UnmarshalJSON(bs []byte) error {
+	return json.Unmarshal(bs, &m.data)
+}
+
+// FromStructId sets the EitherIdOrNamespaceName from a struct {
+// Id string `json:"id,omitempty" mapstructure:"id,omitempty"`
+// }
+func (m *EitherIdOrNamespaceName) FromStructId(data struct {
+	Id string `json:"id,omitempty" mapstructure:"id,omitempty"`
+}) {
+	m.data = data
+}
+
+// FromStructNameNamespace sets the EitherIdOrNamespaceName from a struct {
+// Name string `json:"name,omitempty" mapstructure:"name,omitempty"`
+// Namespace string `json:"namespace,omitempty" mapstructure:"namespace,omitempty"`
+// }
+func (m *EitherIdOrNamespaceName) FromStructNameNamespace(data struct {
+	Name      string `json:"name,omitempty" mapstructure:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty" mapstructure:"namespace,omitempty"`
+}) {
+	m.data = data
+}
+
+// As converts EitherIdOrNamespaceName to a user defined structure.
+func (m EitherIdOrNamespaceName) As(target interface{}) error {
+	return mapstructure.Decode(m.data, target)
+}
+
+// AsStructId converts EitherIdOrNamespaceName to a struct {
+// Id string `json:"id,omitempty" mapstructure:"id,omitempty"`
+// }
+func (m EitherIdOrNamespaceName) AsStructId() (result struct {
+	Id string `json:"id,omitempty" mapstructure:"id,omitempty"`
+}, err error) {
+	return result, mapstructure.Decode(m.data, &result)
+}
+
+// AsStructNameNamespace converts EitherIdOrNamespaceName to a struct {
+// Name string `json:"name,omitempty" mapstructure:"name,omitempty"`
+// Namespace string `json:"namespace,omitempty" mapstructure:"namespace,omitempty"`
+// }
+func (m EitherIdOrNamespaceName) AsStructNameNamespace() (result struct {
+	Name      string `json:"name,omitempty" mapstructure:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty" mapstructure:"namespace,omitempty"`
+}, err error) {
+	return result, mapstructure.Decode(m.data, &result)
+}

--- a/pkg/generators/models/testdata/cases/oneof/generated/model_query_response_row_entry.go
+++ b/pkg/generators/models/testdata/cases/oneof/generated/model_query_response_row_entry.go
@@ -26,17 +26,17 @@ func (m *QueryResponseRowEntry) UnmarshalJSON(bs []byte) error {
 	return json.Unmarshal(bs, &m.data)
 }
 
-// From*string sets the QueryResponseRowEntry data.
+// FromNullableString sets the QueryResponseRowEntry from a *string
 func (m *QueryResponseRowEntry) FromNullableString(data *string) {
 	m.data = data
 }
 
-// FromBool sets the QueryResponseRowEntry data.
+// FromBool sets the QueryResponseRowEntry from a bool
 func (m *QueryResponseRowEntry) FromBool(data bool) {
 	m.data = data
 }
 
-// FromFloat32 sets the QueryResponseRowEntry data.
+// FromFloat32 sets the QueryResponseRowEntry from a float32
 func (m *QueryResponseRowEntry) FromFloat32(data float32) {
 	m.data = data
 }
@@ -46,7 +46,7 @@ func (m QueryResponseRowEntry) As(target interface{}) error {
 	return mapstructure.Decode(m.data, target)
 }
 
-// As*string converts QueryResponseRowEntry to a *string
+// AsNullableString converts QueryResponseRowEntry to a *string
 func (m QueryResponseRowEntry) AsNullableString() (result *string, err error) {
 	return result, mapstructure.Decode(m.data, &result)
 }

--- a/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/expected/model_error.go
+++ b/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/expected/model_error.go
@@ -112,17 +112,17 @@ func (m *Error) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-// FromGenericError sets the Error data.
+// FromGenericError sets the Error from a GenericError
 func (m *Error) FromGenericError(data GenericError) {
 	m.data = data
 }
 
-// FromFieldError sets the Error data.
+// FromFieldError sets the Error from a FieldError
 func (m *Error) FromFieldError(data FieldError) {
 	m.data = data
 }
 
-// FromExternalError sets the Error data.
+// FromExternalError sets the Error from a ExternalError
 func (m *Error) FromExternalError(data ExternalError) {
 	m.data = data
 }

--- a/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/generated/model_error.go
+++ b/pkg/generators/models/testdata/cases/oneof_mapped_discriminator/generated/model_error.go
@@ -112,17 +112,17 @@ func (m *Error) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-// FromGenericError sets the Error data.
+// FromGenericError sets the Error from a GenericError
 func (m *Error) FromGenericError(data GenericError) {
 	m.data = data
 }
 
-// FromFieldError sets the Error data.
+// FromFieldError sets the Error from a FieldError
 func (m *Error) FromFieldError(data FieldError) {
 	m.data = data
 }
 
-// FromExternalError sets the Error data.
+// FromExternalError sets the Error from a ExternalError
 func (m *Error) FromExternalError(data ExternalError) {
 	m.data = data
 }

--- a/pkg/generators/models/testdata/cases/oneof_unmapped_discriminator/expected/model_error.go
+++ b/pkg/generators/models/testdata/cases/oneof_unmapped_discriminator/expected/model_error.go
@@ -103,17 +103,17 @@ func (m *Error) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-// FromGenericError sets the Error data.
+// FromGenericError sets the Error from a GenericError
 func (m *Error) FromGenericError(data GenericError) {
 	m.data = data
 }
 
-// FromFieldError sets the Error data.
+// FromFieldError sets the Error from a FieldError
 func (m *Error) FromFieldError(data FieldError) {
 	m.data = data
 }
 
-// FromExternalError sets the Error data.
+// FromExternalError sets the Error from a ExternalError
 func (m *Error) FromExternalError(data ExternalError) {
 	m.data = data
 }

--- a/pkg/generators/models/testdata/cases/oneof_unmapped_discriminator/generated/model_error.go
+++ b/pkg/generators/models/testdata/cases/oneof_unmapped_discriminator/generated/model_error.go
@@ -103,17 +103,17 @@ func (m *Error) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-// FromGenericError sets the Error data.
+// FromGenericError sets the Error from a GenericError
 func (m *Error) FromGenericError(data GenericError) {
 	m.data = data
 }
 
-// FromFieldError sets the Error data.
+// FromFieldError sets the Error from a FieldError
 func (m *Error) FromFieldError(data FieldError) {
 	m.data = data
 }
 
-// FromExternalError sets the Error data.
+// FromExternalError sets the Error from a ExternalError
 func (m *Error) FromExternalError(data ExternalError) {
 	m.data = data
 }

--- a/pkg/generators/templates/naming.go
+++ b/pkg/generators/templates/naming.go
@@ -1,7 +1,8 @@
 package templates
 
 import (
-	"fmt"
+	"go/ast"
+	"go/parser"
 	"strings"
 )
 
@@ -14,24 +15,46 @@ import (
 //
 //	NullableString
 func TypeDisplayName(value string) string {
-	out := value
-	if strings.HasPrefix(value, "*") {
-		out = strings.Replace(out, "*", "nullable_", 1)
+	expr, error := parser.ParseExpr(value)
+
+	if error != nil {
+		panic(error)
 	}
 
-	if strings.Contains(value, "interface{}") {
-		out = strings.ReplaceAll(out, "interface{}", "interface")
-	}
+	var parts []string
 
-	if strings.Contains(value, "[]") {
-		out = strings.ReplaceAll(out, "[]", "")
+	var f func(n ast.Node) bool
 
-		sliceCount := strings.Count(value, "[]")
-		for sliceCount > 0 {
-			out = fmt.Sprintf("%s_slice", out)
-			sliceCount--
+	f = func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.InterfaceType:
+			parts = append(parts, "interface")
+		case *ast.FieldList:
+			// Not sure if I need to do something here
+		case *ast.StarExpr:
+			parts = append(parts, "nullable")
+		case *ast.Ident:
+			parts = append(parts, x.Name)
+		case *ast.ArrayType:
+			ast.Inspect(x.Elt, f)
+			parts = append(parts, "slice")
+			return false
+		case *ast.StructType:
+			parts = append(parts, "struct")
+		case *ast.Field:
+			for _, name := range x.Names {
+				parts = append(parts, name.Name)
+			}
+			return false
+		case nil:
+			// Nothing to be done
+		default:
+			panic(x)
 		}
+		return true
 	}
 
-	return ToPascalCase(out)
+	ast.Inspect(expr, f)
+
+	return ToPascalCase(strings.Join(parts, "_"))
 }

--- a/pkg/generators/templates/naming_test.go
+++ b/pkg/generators/templates/naming_test.go
@@ -7,9 +7,11 @@ import (
 )
 
 func TestTypeDisplayName(t *testing.T) {
+	require.Equal(t, "Interface", TypeDisplayName("interface{}"))
 	require.Equal(t, "NullableString", TypeDisplayName("*string"))
 	require.Equal(t, "StringSlice", TypeDisplayName("[]string"))
 	require.Equal(t, "InterfaceSlice", TypeDisplayName("[]interface{}"))
 	require.Equal(t, "InterfaceSliceSlice", TypeDisplayName("[][]interface{}"))
 	require.Equal(t, "NullableInterfaceSliceSlice", TypeDisplayName("*[][]interface{}"))
+	require.Equal(t, "StructNamespaceName", TypeDisplayName("struct { Namespace string\nName string }"))
 }


### PR DESCRIPTION
PR 3 for #100:

In case of the following API definition (schema):

```
EitherIdOrNamespaceName:
      description: Either an object with id or a namespace with a name
      nullable: true
      oneOf:
        - type: object
          properties:
            id:
              type: string
        - type: object
          properties:
            namespace:
              type: string
            name:
              type: string
```

the From... and As... functions that are generated (based on anonymous types) where:

1) Generating very long func names based on all the text in the anonymous type definition (including tags)
2) Breaking the templating whilst outputting the comment, while trying to output the anonymous type

Implementation includes a new typename builder based on the golang ast of the type, which should be more secure.

Not sure if you are happy with the panic though :)


## Ticket
#100 

## How Has This Been Verified?
Test cases have been added

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] The change works as expected.
- [ ] New code can be debugged via logs.
- [X] I have added tests to cover my changes.
- [X] I have locally run the tests and all new and existing tests passed.
- [ ] Requires updates to the documentation.
- [ ] I have made the required changes to the documents.
